### PR TITLE
generated workspace 재생성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,11 @@ dist-ssr
 .turbo
 packages/ui/styled-system/*
 **/dist/
-.env
+*.env
+
+styled-system
+styled-system-static
+panda
+panda-static
+outdir
+ts-import-map-outdir

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -13,7 +13,8 @@
   "dependencies": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "ui": "workspace:^"
+    "ui": "workspace:^",
+    "generated": "workspace:^"
   },
   "devDependencies": {
     "@types/react": "^18.3.3",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -14,7 +14,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "ui": "workspace:^",
-    "generated": "workspace:^"
+    "jh-generated": "workspace:^"
   },
   "devDependencies": {
     "@types/react": "^18.3.3",

--- a/packages/generated/package.json
+++ b/packages/generated/package.json
@@ -1,25 +1,33 @@
 {
-  "name": "generated",
+  "name": "jh-generated",
   "type": "module",
   "exports": {
+    "./css" : {
+      "types": "./styled-system/css/index.d.ts",
+      "require": "./styled-system/css/index.mjs",
+      "import": "./styled-system/css/index.mjs"
+    },
     "./cx": {
-      "types": "./css/cx.d.ts",
-      "require": "./css/cx.mjs",
-      "import": "./css/cx.mjs"
+      "types": "./styled-system/css/cx.d.ts",
+      "require": "./styled-system/css/cx.mjs",
+      "import": "./styled-system/css/cx.mjs"
     },
     "./recipes": {
-      "types": "./recipes/index.d.ts",
-      "require": "./recipes/index.mjs",
-      "import": "./recipes/index.mjs"
+      "types": "./styled-system/recipes/index.d.ts",
+      "require": "./styled-system/recipes/index.mjs",
+      "import": "./styled-system/recipes/index.mjs"
     },
     "./tokens": {
-      "types": "./tokens/index.d.ts",
-      "require": "./tokens/index.mjs",
-      "import": "./tokens/index.mjs"
+      "types": "./styled-system/tokens/index.d.ts",
+      "require": "./styled-system/tokens/index.mjs",
+      "import": "./styled-system/tokens/index.mjs"
     },
     "./types": {
-      "types": "./types/index.d.ts"
+      "types": "./styled-system/types/index.d.ts"
     },
-    "./styles.css": "./styles.css"
+    "./types/composition" : {
+      "types": "./styled-system/types/composition.d.ts"
+    },
+    "./styles.css": "./styled-system/styles.css"
   }
 }

--- a/packages/generated/package.json
+++ b/packages/generated/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "generated",
+  "type": "module",
+  "exports": {
+    "./cx": {
+      "types": "./css/cx.d.ts",
+      "require": "./css/cx.mjs",
+      "import": "./css/cx.mjs"
+    },
+    "./recipes": {
+      "types": "./recipes/index.d.ts",
+      "require": "./recipes/index.mjs",
+      "import": "./recipes/index.mjs"
+    },
+    "./tokens": {
+      "types": "./tokens/index.d.ts",
+      "require": "./tokens/index.mjs",
+      "import": "./tokens/index.mjs"
+    },
+    "./types": {
+      "types": "./types/index.d.ts"
+    },
+    "./styles.css": "./styles.css"
+  }
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -36,7 +36,8 @@
     "is-hotkey": "^0.2.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "token": "workspace:^"
+    "token": "workspace:^",
+    "generated": "workspace:^"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^1.5.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -25,7 +25,7 @@
     "dev": "pnpm panda --watch",
     "codegen": "pnpm panda codegen --clean",
     "cssgen": "pnpm panda cssgen -o dist/lib.css",
-    "release": "pnpm panda codegen --clean && vite build && pnpm panda cssgen -o dist/lib.css",
+    "release": "pnpm panda prepare && vite build && pnpm panda cssgen -o dist/lib.css",
     "check-types": "tsc --noEmit",
     "local": "vite"
   },

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -37,7 +37,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "token": "workspace:^",
-    "generated": "workspace:^"
+    "jh-generated": "workspace:^"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^1.5.0",

--- a/packages/ui/panda.config.ts
+++ b/packages/ui/panda.config.ts
@@ -69,7 +69,7 @@ export default defineConfig({
     textStyles,
   },
   // The output directory for your css system
-  outdir: "./styled-system",
+  outdir: "../generated/styled-system",
   importMap: "jh-generated",
   staticCss: {
     recipes: {

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -2,12 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "noImplicitAny": true,
-    "baseUrl": ".",
-    "paths": {
-      "jh-generated/*": ["styled-system/*"],
-      "jh-generated/cx": ["styled-system/css/cx"]
-    }
+    "noImplicitAny": true
   },
   "include": ["src/**/*"],
   "exclude": ["stories", "node_modules"]

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -2,10 +2,9 @@ import { defineConfig } from "vite"
 import react from "@vitejs/plugin-react"
 import dts from "vite-plugin-dts"
 import { resolve } from "path"
-import tsconfigPaths from "vite-tsconfig-paths"
 
 export default defineConfig({
-  plugins: [react(), dts(), tsconfigPaths()],
+  plugins: [react(), dts()],
   build: {
     lib: {
       entry: resolve(__dirname, "src/components/index.ts"),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
 
   packages/app:
     dependencies:
+      jh-generated:
+        specifier: workspace:^
+        version: link:../generated
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -100,6 +103,8 @@ importers:
         specifier: ^5.2.2
         version: 5.5.3
 
+  packages/generated: {}
+
   packages/script:
     devDependencies:
       plop:
@@ -122,6 +127,9 @@ importers:
       is-hotkey:
         specifier: ^0.2.0
         version: 0.2.0
+      jh-generated:
+        specifier: workspace:^
+        version: link:../generated
       react:
         specifier: ^18.2.0
         version: 18.3.1


### PR DESCRIPTION
1. 기존의 `generated` workspace에 pandacss의 output 파일들과 css파일을 생성했으나, gitignore에 `generated` workspace를 추가하면서, ci 과정에서 generated에 output이 생성은 되나, package.json 파일이 없기 때문에 기존의 export에 명시했던 경로를 해석하지 못함

2. 이 문제를 해결하기 위해 해당 workspace를 삭제 후, ui workspace에 직접 해당 파일들을 위치시킴

3. 2번 방법은 pandacss에서 권장하는 방법이 아니고,

> By de-coupling the component library from the styled-system, your users can share the same runtime code between your library and their app code.

1번 문제의 해결 방법으로, generated workspace에 package.json파일만 git에 올리기만 하면 되기 때문에 다시 1번 방법으로 되돌아가기 위해 관련 문제들을 수정