### PR TITLE
캐싱을 통한 ci 시간 단축

### DIFF
--- a/.github/actions/playwright/action.yml
+++ b/.github/actions/playwright/action.yml
@@ -4,7 +4,6 @@ runs:
   using: composite
 
   steps:
-    # https://github.com/microsoft/playwright/issues/7249#issuecomment-1373375487
     - name: Get playwright version
       shell: bash
       run: |

--- a/.github/actions/playwright/action.yml
+++ b/.github/actions/playwright/action.yml
@@ -8,7 +8,7 @@ runs:
     - name: Get playwright version
       shell: bash
       run: |
-        echo "PLAYWRIGHT_VERSION=$(node -e "process.stdout.write(require('@playwright/test/package.json').version)")" >> $GITHUB_OUTPUT
+        echo "PLAYWRIGHT_VERSION=$(node -e "process.stdout.write(require('playwright/package.json').version)")" >> $GITHUB_OUTPUT
       id: playwright-version
 
     - name: Cache Playwright Browsers for Playwright's Version

--- a/.github/actions/playwright/action.yml
+++ b/.github/actions/playwright/action.yml
@@ -1,0 +1,25 @@
+name: playwright-install
+
+runs:
+  using: composite
+
+  steps:
+    # https://github.com/microsoft/playwright/issues/7249#issuecomment-1373375487
+    - name: Get playwright version
+      shell: bash
+      run: |
+        echo "PLAYWRIGHT_VERSION=$(node -e "process.stdout.write(require('@playwright/test/package.json').version)")" >> $GITHUB_OUTPUT
+      id: playwright-version
+
+    - name: Cache Playwright Browsers for Playwright's Version
+      uses: actions/cache@v4
+      with:
+        # https://playwright.dev/docs/browsers#managing-browser-binaries
+        path: ~/.cache/ms-playwright
+        key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.PLAYWRIGHT_VERSION }}
+      id: cache-playwright-browsers
+
+    - name: Setup Playwright
+      shell: bash
+      if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
+      run: npx playwright install --with-deps

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -19,8 +19,6 @@ runs:
 
     - name: Install pnpm
       uses: pnpm/action-setup@v4
-      with:
-        version: 9
 
     - name: Get pnpm store directory
       shell: bash

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -37,6 +37,7 @@ runs:
 
     - name: Install dependencies
       run: pnpm install
+      shell: bash
 
     - name: Check if Playwright browser is cached
       uses: actions/cache@v3

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,10 +1,6 @@
 name: pnpm setup
 description: pnpm setup
-inputs:
-  node-version:
-    description: "Node.js version"
-    required: true
-    default: "20"
+
 runs:
   using: composite
   steps:
@@ -16,18 +12,31 @@ runs:
         restore-keys: |
           ${{ runner.os }}-turbo-
 
-    - name: Install pnpm
-      uses: pnpm/action-setup@v4
-
-    - name: Use Node.js ${{ inputs.node-version }}
+    - name: Use Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: ${{ inputs.node-version }}
-        cache: "pnpm"
+        node-version-file: .nvmrc
+
+    - name: Install pnpm
+      uses: pnpm/action-setup@v4
+      with:
+        version: 9
+
+    - name: Get pnpm store directory
+      shell: bash
+      run: |
+        echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+    - uses: actions/cache@v4
+      name: Setup pnpm cache
+      with:
+        path: ${{ env.STORE_PATH }}
+        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-pnpm-store-
 
     - name: Install dependencies
       run: pnpm install
-      shell: bash
 
     - name: Check if Playwright browser is cached
       uses: actions/cache@v3
@@ -43,8 +52,4 @@ runs:
 
     - run: npx playwright install-deps
       if: steps.playwright-cache.outputs.cache-hit == 'true'
-      shell: bash
-
-    - name: Run CI
-      run: pnpm run ci
       shell: bash

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -37,18 +37,18 @@ runs:
       run: pnpm install
       shell: bash
 
-    - name: Check if Playwright browser is cached
-      uses: actions/cache@v3
-      id: playwright-cache
-      with:
-        path: |
-          ~/.cache/ms-playwright
-        key: ${{ runner.os }}-playwright-1.28.0
+    # - name: Check if Playwright browser is cached
+    #   uses: actions/cache@v3
+    #   id: playwright-cache
+    #   with:
+    #     path: |
+    #       ~/.cache/ms-playwright
+    #     key: ${{ runner.os }}-playwright-1.28.0
 
-    - run: npx playwright install --with-deps
-      if: steps.playwright-cache.outputs.cache-hit != 'true'
-      shell: bash
+    # - run: npx playwright install --with-deps
+    #   if: steps.playwright-cache.outputs.cache-hit != 'true'
+    #   shell: bash
 
-    - run: npx playwright install-deps
-      if: steps.playwright-cache.outputs.cache-hit == 'true'
-      shell: bash
+    # - run: npx playwright install-deps
+    #   if: steps.playwright-cache.outputs.cache-hit == 'true'
+    #   shell: bash

--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -18,8 +18,6 @@ jobs:
 
       - name: pnpm setup
         uses: ./.github/actions/setup
-        with:
-          node-version: 20
 
       - name: Setup npmrc
         run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,5 +16,8 @@ jobs:
       - name: ci setup
         uses: ./.github/actions/setup
 
-        with:
-          node-version: 20
+      - name: playwright setup
+        uses: ./.github/actions/playwright
+
+      - name: run ci
+        run: pnpm run ci


### PR DESCRIPTION
## Overview
close #54 
- 의존성 설치 관련 캐싱 적용(5f242d5f4c46b0c5137623b30644c27650541c7f)
- playwright 다운로드 관련 캐싱 적용(ca13823a72bc5fddfc1179b8da0c34b195318589)

=> ci 시간 4분 -> 40초(모든 부분 캐싱+ remote caching으로 full turbo시)
- full turbo가 아닐 시 +10~20 예상