### PR TITLE
github actions 캐싱 테스트를 위한 PR 및 작업 정리

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -4,17 +4,7 @@ export default {
     "type-enum": [
       2,
       "always",
-      [
-        "feat",
-        "fix",
-        "docs",
-        "style",
-        "refactor",
-        "test",
-        "chore",
-        "revert",
-        "release",
-      ],
+      ["feat", "fix", "docs", "style", "refactor", "test", "chore", "release"],
     ],
   },
 }


### PR DESCRIPTION
## ✨ 설명
- github actions의 캐싱 테스트를 위한 PR이지만, 지금까지 한 작업들을 정리
## 📌 참고 사항
#44
### 이전까지의 문제점
1. 캐싱이 제대로 되지 않음
- 직전의 pr merge를 통해 캐시가 되었고, actions의 cache 탭에 가면 캐싱 데이터를 확실히 확인할 수 있지만, 이후 다른 브랜치를 파서 pr 올릴 경우 이를 불러오지 못하고 있었음(패키지 변화나 버전 변화 X)
- but pr을 sync, reopen할 경우 캐시 데이터를 불러옴
=> 캐싱이 공유가 안되고 있음
=> 원래 캐시 공유가 안되나? O [issue](https://github.com/orgs/community/discussions/27059) 
- 캐시라는건 브랜치마다 생성되는걸로 파악됨(cache 탭에 가도 브랜치명이 쓰여있음) 
- default 브랜치에 캐싱데이터가 존재한다면 -> 다른 브랜치에서 사용 가능
- 나의 경우는 작업용 브랜치를 팔때마다 각각 캐시 데이터가 그 브랜치에 저장됨 -> 다른 브랜치를 팔 경우 공유가 안됨
- 저번 작업때 캐시가 적용되었던 이유는 ci workspace가 syncronize로 retrigger되었기 때문에 +  turbo cache때문에 빨라보였던 것

### 해결방안
1. default 브랜치(dev)에 캐시 데이터를 올려놔야 함
- workflow를 하나 더 만들어서 , default에 push되면 캐싱 작업을 수행하면 됨
- push 이벤트 발생 시 key를 비교해서 변경되었을 시 캐싱하기

### 문제점
- 급하게 변경하느라 기존에 ci에서 쓰던 actions를 그대로 사용하고 있음, 불필요한 과정이 존재
- 기존의 ci에서는 그러면 캐싱을 안해도 되는게 아닌가? -> 캐시 hit 시에는 따로 캐시를 저장하지 않는 것 같음

