### PR TITLE
npm 패키지 배포 관련 CD 구축

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
   "access": "public",
   "baseBranch": "dev",
   "updateInternalDependencies": "patch",
-  "ignore": ["app","script"]
+  "ignore": ["docs", "script"]
 }

--- a/.changeset/neat-baboons-dance.md
+++ b/.changeset/neat-baboons-dance.md
@@ -1,0 +1,5 @@
+---
+"panda-animation": patch
+---
+
+initial

--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - dev
     paths:
-      - ".changeset/**" # .changeset 폴더에 변경이 있을 때만 실행env:
+      - ".changeset/**" # .changeset 폴더에 변경이 있을 때만 실행
 env:
   CI: true
   PNPM_CACHE_FOLDER: .pnpm-store
@@ -18,6 +18,9 @@ jobs:
 
       - name: pnpm setup
         uses: ./.github/actions/setup
+
+      - name: build
+        uses: pnpm turbo build
 
       - name: Setup npmrc
         run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc

--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@ node_modules
 .yalc/*
 
 .next
-
+out
 # Logs
 logs
 *.log

--- a/app/docs/next.config.ts
+++ b/app/docs/next.config.ts
@@ -3,6 +3,7 @@ import type { NextConfig } from "next"
 const nextConfig: NextConfig = {
   /* config options here */
   output: "export",
+  trailingSlash: true,
 }
 
 export default nextConfig

--- a/package.json
+++ b/package.json
@@ -8,17 +8,12 @@
     "dev": "vite",
     "lint": "eslint . --ignore-pattern 'styled-system/'",
     "preinstall": "npx only-allow pnpm",
-    "tokens": "pnpm --filter token",
-    "app": "pnpm --filter app",
-    "ui": "pnpm --filter ui",
-    "script": "pnpm --filter script",
-    "preset": "pnpm --filter panda-preset",
     "prepare": "husky",
     "lint-staged": "lint-staged",
     "commit": "git-cz",
     "ci:version": "changeset version",
     "ci:publish": "changeset publish -r",
-    "ci": "turbo run lint check-type test build"
+    "ci": "turbo run lint check-type test"
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.10",

--- a/turbo.json
+++ b/turbo.json
@@ -2,7 +2,7 @@
   "$schema": "https://turbo.build/schema.json",
   "tasks": {
     "build": {
-      "outputs": ["dist/**"],
+      "outputs": ["dist/**", ".next/**", "out/**"],
       "dependsOn": ["^build"]
     },
     "check-type": {},


### PR DESCRIPTION
## ✨ 설명
- npm에 배포되어야 할 패키지들의 CD 구축
- 아카이빙용
## 🔍 주요 변경 사항
- [ ] workflow 스크립트 변경
- [ ] package.json 스크립트 일부 변경
- [ ] turbo.json 설정 변경

## ✅ 테스트 결과

## 📌 참고 사항
1. 현재 지켜져야 할 빌드 순서
- 하나의 패키지에서 의존성으로 가지고 있는 패키지들이 먼저 빌드된 후 빌드 되어야 하는 건 모든 패키지 동일
- `docs`의 경우 `cli` 패키지의 빌드가 끝나고, `build-registry` 스크립트가 실행된 다음 빌드 되어야 함
- `cli`의 경우 `ui` 패키지의 빌드가 끝난 다음 빌드되어야 함 -> ui의 경우 따로 빌드하지 않고 있기 때문에 해당 과정에서는 이미 최신화 되어있음
-> turborepo를 활용하여 빌드 순서 정상화
