### PR TITLE
Add CLI 에러 핸들링 로직 추가

### DIFF
--- a/app/docs/src/components/button/index.tsx
+++ b/app/docs/src/components/button/index.tsx
@@ -1,13 +1,14 @@
 import { styled, type HTMLStyledProps } from "@styled-system/jsx"
 import { button } from "@styled-system/recipes"
-import * as React from "react"
+import type { ComponentPropsWithoutRef } from "react"
+import { forwardRef } from "react"
 import { Slot } from "@radix-ui/react-slot"
 
-export type BaseButtonProps = React.ComponentPropsWithoutRef<"button"> & {
+export type BaseButtonProps = ComponentPropsWithoutRef<"button"> & {
   asChild?: boolean
 }
 
-export const BaseButton = React.forwardRef<HTMLButtonElement, BaseButtonProps>(
+export const BaseButton = forwardRef<HTMLButtonElement, BaseButtonProps>(
   ({ asChild, ...props }, ref) => {
     const Comp = asChild ? Slot : "button"
 
@@ -15,7 +16,7 @@ export const BaseButton = React.forwardRef<HTMLButtonElement, BaseButtonProps>(
   },
 )
 
-BaseButton.displayName = ""
+BaseButton.displayName = "Button"
 
 export const Button = styled(BaseButton, button)
 export type ButtonProps = HTMLStyledProps<typeof Button>

--- a/app/docs/src/components/button/recipe.ts
+++ b/app/docs/src/components/button/recipe.ts
@@ -14,10 +14,9 @@ export const buttonRecipe = defineSafe.recipe({
     cursor: "pointer",
     gap: "2",
     _focusVisible: {
-      outlineColor: "background",
-      outlineWidth: "2px",
+      ringWidth: "1",
       ringColor: "ring",
-      ringOffset: "2",
+      ringOffset: "1",
     },
 
     _disabled: {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -6,6 +6,8 @@
   "type": "module",
   "scripts": {
     "build": "tsup && npx tsx ./src/build-script.ts --all",
+    "build:cli": "tsup",
+    "build:registry": "npx tsx ./src/build-script.ts --all",
     "release": "pnpm publish -no-git-checks",
     "lint": "eslint . --max-warnings 0",
     "check-type": "tsc --noEmit",
@@ -29,6 +31,7 @@
     "@effect/platform": "^0.69.13",
     "@effect/schema": "^0.75.5",
     "@types/babel__traverse": "^7.20.6",
+    "chalk": "^5.4.1",
     "commander": "^13.0.0",
     "effect": "^3.10.8",
     "execa": "^9.5.2",

--- a/packages/cli/src/add/index.ts
+++ b/packages/cli/src/add/index.ts
@@ -6,7 +6,7 @@ import { confirm } from "@clack/prompts"
 
 import { loadComponentConfig, loadTSConfig } from "./utils/config"
 import {
-  getPandacssConfigFile,
+  getPandacssConfigPath,
   resolvePandaConfig,
 } from "../common/utils/directoryUtils"
 import { resolveImport } from "./utils/resolveImport"
@@ -50,7 +50,7 @@ export const addCommand = new Command()
 
       const tsconfig = await loadTSConfig(options.cwd)
       //3. panda.config.* 파일을 읽어온다
-      const PandaConfigPath = await getPandacssConfigFile(options.cwd)
+      const PandaConfigPath = await getPandacssConfigPath(options.cwd)
 
       if (!PandaConfigPath) {
         throw new Error("panda.config.* file not found")

--- a/packages/cli/src/add/index.ts
+++ b/packages/cli/src/add/index.ts
@@ -35,121 +35,127 @@ export const addCommand = new Command()
     process.cwd(),
   )
   .action(async (components, opts) => {
-    const options = addSchema.parse({
-      components,
-      cwd: path.resolve(opts.cwd),
-      ...opts,
-    })
+    try {
+      const options = addSchema.parse({
+        components,
+        cwd: path.resolve(opts.cwd),
+        ...opts,
+      })
 
-    //1. components.json 파일을 읽어온다
-    const components_json = await loadComponentConfig(options.cwd)
+      //1. components.json 파일을 읽어온다
+      const components_json = configSchema.schema.parse(
+        loadComponentConfig(options.cwd),
+      )
+      //2. tsconfig.json 파일을 읽어온다
 
-    //2. tsconfig.json 파일을 읽어온다
+      const tsconfig = await loadTSConfig(options.cwd)
+      //3. panda.config.* 파일을 읽어온다
+      const PandaConfigPath = await getPandacssConfigFile(options.cwd)
 
-    const tsconfig = await loadTSConfig(options.cwd)
-
-    //3. panda.config.* 파일을 읽어온다
-    const PandaConfigPath = await getPandacssConfigFile(options.cwd)
-
-    if (!PandaConfigPath) {
-      throw new Error("panda.config.* file not found")
-    }
-    const config = await fs.readFile(
-      path.resolve(options.cwd, PandaConfigPath),
-      "utf-8",
-    )
-
-    const { outdir } = await resolvePandaConfig(config)
-    //최종 경로
-
-    const paths = configSchema.schema.parse({
-      utils: await resolveImport(components_json.utils, tsconfig),
-      components: await resolveImport(components_json.components, tsconfig),
-      hooks: await resolveImport(components_json.hooks, tsconfig),
-      styledsystem: path.join(options.cwd, outdir || "styled-system"),
-    })
-
-    //fetch
-    const componentList = options.components?.map((c) => c.toLowerCase())
-
-    if (!componentList?.length) {
-      return
-    }
-    const results = await Promise.allSettled(
-      componentList?.map(async (c) => {
-        const response = await fetch(`${BASE_URL}/${c}.json`)
-        if (!response.ok) {
-          throw new Error(`Failed to fetch ${c}`)
-        }
-        const data = await response.json()
-        return data
-      }),
-    )
-
-    results.forEach(async (result, index) => {
-      if (result.status === "fulfilled") {
-        //1. registry schema check
-        const registry = registrySchema.parse(result.value)
-        //2.폴더를 하나 생성해야 함 -> 폴더이름은 reigstry.name
-        const src = path.join(paths.components, componentList[index])
-        const isExists = await fs.pathExists(src)
-
-        if (isExists) {
-          const isAgreed = await confirm({
-            message: `Component ${componentList[index]} already exists. Do you want to overwrite it?`,
-          })
-          if (!isAgreed) {
-            return
-          }
-        }
-        //이후부터는 파일을 overwrite
-        await fs.ensureDir(path.resolve(src))
-
-        registry.files?.forEach((file) => {
-          const convertedContent = transformImports(
-            file.content,
-            components_json,
-          )
-
-          if (file.name === "recipe.ts") {
-            //현재 export하고있는 recipe 변수명은 componentList[index]+Recipe
-            //이걸 preset.ts에 넣어줘야 함 - 현재는 이 파일이 root에 있다고 가정
-            //이 파일의 alias는 component alias / 컴포넌트명 / recipe.ts
-            transformPreset(
-              path.join(options.cwd, "preset.ts"),
-              `${componentList[index]}`,
-              path.join(
-                components_json.components,
-                `${componentList[index]}`,
-                "recipe",
-              ),
-            )
-          }
-          if (file.type === "ui") {
-            fs.writeFileSync(path.join(src, file.name), convertedContent)
-          } else {
-            fs.outputFileSync(
-              path.join(paths[file.type], file.name),
-              convertedContent,
-              "utf-8",
-            )
-          }
-        })
-
-        const pm = await detect({ cwd: options.cwd })
-        if (!pm) {
-          throw new Error("Could not detect package manager")
-        }
-        if (registry.dependencies?.length) {
-          await execa(pm.name, [
-            pm.name === "npm" ? "install" : "add",
-            ...registry.dependencies,
-          ])
-        }
-        const runner = await getPackageManagerRunner(options.cwd)
-        const [name, ...cmd] = runner.split(" ")
-        execa(name, [...cmd, "panda", "codegen"])
+      if (!PandaConfigPath) {
+        throw new Error("panda.config.* file not found")
       }
-      console.log(`${componentList[index]} completed successfully`)
-    })
+      const config = await fs.readFile(
+        path.resolve(options.cwd, PandaConfigPath),
+        "utf-8",
+      )
+
+      const { outdir } = await resolvePandaConfig(config)
+      //최종 경로
+
+      const paths = configSchema.schema.parse({
+        utils: await resolveImport(components_json.utils, tsconfig),
+        components: await resolveImport(components_json.components, tsconfig),
+        hooks: await resolveImport(components_json.hooks, tsconfig),
+        styledsystem: path.join(options.cwd, outdir || "styled-system"),
+      })
+
+      //fetch
+      const componentList = options.components?.map((c) => c.toLowerCase())
+
+      if (!componentList?.length) {
+        return
+      }
+      const results = await Promise.allSettled(
+        componentList?.map(async (c) => {
+          const response = await fetch(`${BASE_URL}/${c}.json`)
+          if (!response.ok) {
+            throw new Error(`Failed to fetch ${c}`)
+          }
+          const data = await response.json()
+          return data
+        }),
+      )
+
+      results.forEach(async (result, index) => {
+        if (result.status === "fulfilled") {
+          //1. registry schema check
+          const registry = registrySchema.parse(result.value)
+          //2.폴더를 하나 생성해야 함 -> 폴더이름은 reigstry.name
+          const src = path.join(paths.components, componentList[index])
+          const isExists = await fs.pathExists(src)
+
+          if (isExists) {
+            const isAgreed = await confirm({
+              message: `Component ${componentList[index]} already exists. Do you want to overwrite it?`,
+            })
+            if (!isAgreed) {
+              return
+            }
+          }
+          //이후부터는 파일을 overwrite
+          await fs.ensureDir(path.resolve(src))
+
+          registry.files?.forEach((file) => {
+            const convertedContent = transformImports(
+              file.content,
+              components_json,
+            )
+
+            if (file.name === "recipe.ts") {
+              //현재 export하고있는 recipe 변수명은 componentList[index]+Recipe
+              //이걸 preset.ts에 넣어줘야 함 - 현재는 이 파일이 root에 있다고 가정
+              //이 파일의 alias는 component alias / 컴포넌트명 / recipe.ts
+              transformPreset(
+                path.join(options.cwd, "preset.ts"),
+                `${componentList[index]}`,
+                path.join(
+                  components_json.components,
+                  `${componentList[index]}`,
+                  "recipe",
+                ),
+              )
+            }
+            if (file.type === "ui") {
+              fs.writeFileSync(path.join(src, file.name), convertedContent)
+            } else {
+              fs.outputFileSync(
+                path.join(paths[file.type], file.name),
+                convertedContent,
+                "utf-8",
+              )
+            }
+          })
+
+          const pm = await detect({ cwd: options.cwd })
+          if (!pm) {
+            throw new Error("Could not detect package manager")
+          }
+          if (registry.dependencies?.length) {
+            await execa(pm.name, [
+              pm.name === "npm" ? "install" : "add",
+              ...registry.dependencies,
+            ])
+          }
+          const runner = await getPackageManagerRunner(options.cwd)
+          const [name, ...cmd] = runner.split(" ")
+          execa(name, [...cmd, "panda", "codegen"])
+        }
+        console.log(`${componentList[index]} completed successfully`)
+      })
+    } catch (e) {
+      if (e instanceof Error) {
+        console.log(e.message, e.cause)
+      }
+    }
   })

--- a/packages/cli/src/add/utils/config.ts
+++ b/packages/cli/src/add/utils/config.ts
@@ -4,7 +4,7 @@ import path from "path"
 import { loadConfig } from "tsconfig-paths"
 import { resolveImport } from "./resolveImport"
 import { type ConfigLoaderSuccessResult } from "tsconfig-paths"
-import { ConfigError } from "../../common/error"
+import { ErrorMap } from "../../common/error"
 
 // components.json 파일 읽기 전용
 export function loadComponentConfig(cwd: string) {
@@ -12,8 +12,10 @@ export function loadComponentConfig(cwd: string) {
     const configFile = fs.readJsonSync(path.resolve(cwd, configSchema.fileName))
     return configFile
   } catch (e) {
-    throw new ConfigError(`cannot find components.json relative to ${cwd}`, {
-      cause: e,
+    return ErrorMap({
+      code: "config_not_found",
+      configFile: configSchema.fileName,
+      message: [e instanceof Error ? e.message : ""],
     })
   }
 }
@@ -23,8 +25,10 @@ export function loadComponentConfig(cwd: string) {
 export async function loadTSConfig(cwd: string) {
   const tsconfig = loadConfig(cwd)
   if (tsconfig.resultType === "failed") {
-    throw new ConfigError(`cannot find tsconfig.json relative to ${cwd}`, {
-      cause: tsconfig.message,
+    throw ErrorMap({
+      code: "config_not_found",
+      configFile: "tsconfig.json",
+      message: ["cannot found tsconfig.json"],
     })
   }
   return tsconfig

--- a/packages/cli/src/add/utils/resolveImport.ts
+++ b/packages/cli/src/add/utils/resolveImport.ts
@@ -1,6 +1,5 @@
-import { ConfigError } from "../../common/error"
+import { ErrorMap } from "../../common/error"
 import { createMatchPath, type ConfigLoaderSuccessResult } from "tsconfig-paths"
-
 export async function resolveImport(
   importPath: string,
   config: Pick<ConfigLoaderSuccessResult, "absoluteBaseUrl" | "paths">,
@@ -11,8 +10,11 @@ export async function resolveImport(
     () => true,
   )
   if (!match) {
-    throw new ConfigError("cannot resolve your tsconfig import", {
-      cause: "no match found",
+    throw ErrorMap({
+      code: "resolve_path_fail",
+      target: importPath,
+      cwd: process.cwd(),
+      message: ["resolve error"],
     })
   }
   return match

--- a/packages/cli/src/add/utils/resolveImport.ts
+++ b/packages/cli/src/add/utils/resolveImport.ts
@@ -1,13 +1,19 @@
+import { ConfigError } from "../../common/error"
 import { createMatchPath, type ConfigLoaderSuccessResult } from "tsconfig-paths"
 
 export async function resolveImport(
   importPath: string,
   config: Pick<ConfigLoaderSuccessResult, "absoluteBaseUrl" | "paths">,
 ) {
-  return createMatchPath(config.absoluteBaseUrl, config.paths)(
+  const match = createMatchPath(config.absoluteBaseUrl, config.paths)(
     importPath,
     undefined,
     () => true,
-    [".ts", ".tsx"],
   )
+  if (!match) {
+    throw new ConfigError("cannot resolve your tsconfig import", {
+      cause: "no match found",
+    })
+  }
+  return match
 }

--- a/packages/cli/src/add/utils/transform.ts
+++ b/packages/cli/src/add/utils/transform.ts
@@ -67,17 +67,33 @@ export function transformPreset(
 
   if (!objectLiteral) return
 
-  // 새로운 import 문 추가
-  sourceFile.addImportDeclaration({
-    moduleSpecifier: recipePath,
-    namedImports: [{ name: `${recipeName}Recipe` }],
-  })
+  const isImportExists = sourceFile
+    .getImportDeclarations()
+    .some((importDeclaration) => {
+      const moduleSpecifier = importDeclaration.getModuleSpecifierValue()
+      const namedImports = importDeclaration.getNamedImports()
+      return (
+        moduleSpecifier === recipePath &&
+        namedImports.some(
+          (importSpecifier) =>
+            importSpecifier.getName() === `${recipeName}Recipe`,
+        )
+      )
+    })
 
-  // recipes 객체에 새로운 속성 추가
-  objectLiteral.addPropertyAssignment({
-    name: recipeName,
-    initializer: `${recipeName}Recipe`,
-  })
+  // 새로운 import 문 추가
+  if (!isImportExists) {
+    sourceFile.addImportDeclaration({
+      moduleSpecifier: recipePath,
+      namedImports: [{ name: `${recipeName}Recipe` }],
+    })
+
+    // recipes 객체에 새로운 속성 추가
+    objectLiteral.addPropertyAssignment({
+      name: recipeName,
+      initializer: `${recipeName}Recipe`,
+    })
+  }
 
   // 변경사항 저장
   sourceFile.saveSync()

--- a/packages/cli/src/common/error/index.ts
+++ b/packages/cli/src/common/error/index.ts
@@ -59,3 +59,24 @@ export class CommandError extends Error {
     return this.issue.message?.join("\n")
   }
 }
+
+export const ErrorMap = (issue: Issue) => {
+  let message: string
+  switch (issue.code) {
+    case ISSUE_CODE.config_not_found:
+      message = `error occured while config ${issue.configFile}`
+      break
+    case ISSUE_CODE.resolve_path_fail:
+      message = `failed to resolve your path, current ${issue.cwd}`
+      break
+    case ISSUE_CODE.failed_to_fetch: //TODO: statusCode별 에러메시지 필요
+      message = `failed to fetch ${issue.target} [${issue.statusCode}]`
+      break
+    default:
+      message = "error occured"
+  }
+  return new CommandError({
+    ...issue,
+    message: [...(issue.message || ""), message],
+  })
+}

--- a/packages/cli/src/common/error/index.ts
+++ b/packages/cli/src/common/error/index.ts
@@ -1,7 +1,59 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export const arrayToEnum = <T extends string, U extends [T, ...T[]]>(
+  items: U,
+): { [k in U[number]]: k } => {
+  const obj: any = {}
+  for (const item of items) {
+    obj[item] = item
+  }
+  return obj as any
+}
+
 export class ConfigError extends Error {
   constructor(message: string, { cause }: { cause?: unknown }) {
     super(message)
     this.name = "ConfigError"
     this.cause = cause
+  }
+}
+
+export const ISSUE_CODE = arrayToEnum(["config_not_found", "resolve_path_fail"])
+
+export const FILE_TYPE = arrayToEnum([
+  "components.json",
+  "tsconfig.json",
+  "panda.config.*",
+  "package.json",
+])
+
+export type IssueBase = {
+  path: string[]
+  message?: string | string[]
+}
+
+export interface ConfigNotFoundIssue extends IssueBase {
+  code: typeof ISSUE_CODE.config_not_found
+  configFile: keyof typeof FILE_TYPE
+}
+
+export interface ResolvePathFailIssue extends IssueBase {
+  code: typeof ISSUE_CODE.resolve_path_fail
+  target: string
+  cwd: string
+}
+
+export type Issue = ResolvePathFailIssue | ConfigNotFoundIssue
+
+export class CommandError extends Error {
+  issue: Issue
+  constructor(issue: Issue) {
+    super()
+    this.name = "NewError"
+    this.issue = issue
+  }
+
+  format() {
+    this.issue //문자열 출력 담당해주면됨
   }
 }

--- a/packages/cli/src/common/error/index.ts
+++ b/packages/cli/src/common/error/index.ts
@@ -39,13 +39,13 @@ export interface ResolvePathFailIssue extends IssueBase {
   cwd: string
 }
 
-export interface FetchError extends IssueBase {
+export interface FetchIssue extends IssueBase {
   code: typeof ISSUE_CODE.failed_to_fetch
   target: string
-  statusCode: number
+  statusCode: number | null
 }
 
-export type Issue = ResolvePathFailIssue | ConfigNotFoundIssue | FetchError
+export type Issue = ResolvePathFailIssue | ConfigNotFoundIssue | FetchIssue
 
 export class CommandError extends Error {
   issue: Issue

--- a/packages/cli/src/common/error/index.ts
+++ b/packages/cli/src/common/error/index.ts
@@ -1,0 +1,7 @@
+export class ConfigError extends Error {
+  constructor(message: string, { cause }: { cause?: unknown }) {
+    super(message)
+    this.name = "ConfigError"
+    this.cause = cause
+  }
+}

--- a/packages/cli/src/common/error/index.ts
+++ b/packages/cli/src/common/error/index.ts
@@ -56,7 +56,7 @@ export class CommandError extends Error {
   }
 
   get format() {
-    return this.issue.message?.join("\n")
+    return this.issue.code + "\n" + this.issue.message?.join("\n")
   }
 }
 

--- a/packages/cli/src/common/error/index.ts
+++ b/packages/cli/src/common/error/index.ts
@@ -10,15 +10,11 @@ export const arrayToEnum = <T extends string, U extends [T, ...T[]]>(
   return obj as any
 }
 
-export class ConfigError extends Error {
-  constructor(message: string, { cause }: { cause?: unknown }) {
-    super(message)
-    this.name = "ConfigError"
-    this.cause = cause
-  }
-}
-
-export const ISSUE_CODE = arrayToEnum(["config_not_found", "resolve_path_fail"])
+export const ISSUE_CODE = arrayToEnum([
+  "config_not_found",
+  "resolve_path_fail",
+  "failed_to_fetch",
+])
 
 export const FILE_TYPE = arrayToEnum([
   "components.json",
@@ -28,8 +24,8 @@ export const FILE_TYPE = arrayToEnum([
 ])
 
 export type IssueBase = {
-  path: string[]
-  message?: string | string[]
+  code: keyof typeof ISSUE_CODE
+  message?: string[]
 }
 
 export interface ConfigNotFoundIssue extends IssueBase {
@@ -43,7 +39,13 @@ export interface ResolvePathFailIssue extends IssueBase {
   cwd: string
 }
 
-export type Issue = ResolvePathFailIssue | ConfigNotFoundIssue
+export interface FetchError extends IssueBase {
+  code: typeof ISSUE_CODE.failed_to_fetch
+  target: string
+  statusCode: number
+}
+
+export type Issue = ResolvePathFailIssue | ConfigNotFoundIssue | FetchError
 
 export class CommandError extends Error {
   issue: Issue
@@ -53,7 +55,7 @@ export class CommandError extends Error {
     this.issue = issue
   }
 
-  format() {
-    this.issue //문자열 출력 담당해주면됨
+  get format() {
+    return this.issue.message?.join("\n")
   }
 }

--- a/packages/cli/src/common/utils/directoryUtils.ts
+++ b/packages/cli/src/common/utils/directoryUtils.ts
@@ -2,7 +2,7 @@ import fg from "fast-glob"
 import fs from "fs-extra"
 import { loadConfig } from "tsconfig-paths"
 import path from "path"
-import { ConfigError } from "../error"
+import { ErrorMap } from "../error"
 
 export function getTsConfigAlias(cwd: string, styledSytemPath: string) {
   const tsConfig = loadConfig(cwd)
@@ -47,14 +47,22 @@ export async function getPandacssConfigPath(cwd: string) {
   try {
     const files = await fg.glob(["panda.config.*"], { cwd, deep: 3 })
     if (!files.length) {
-      throw new ConfigError(`Panda CSS config file not found in ${cwd}`, {
-        cause: "File Not Found",
+      throw ErrorMap({
+        code: "config_not_found",
+        configFile: "panda.config.*",
+        message: ["failed to find panda.config file"],
       })
     }
     return files[0]
   } catch (error) {
-    throw new ConfigError(`Failed to find Panda CSS config file in ${cwd}`, {
-      cause: error,
+    throw ErrorMap({
+      code: "config_not_found",
+      configFile: "panda.config.*",
+      message: [
+        error instanceof Error
+          ? error.message
+          : "unknown error occured finding panda.config",
+      ],
     })
   }
 }

--- a/packages/cli/src/common/utils/directoryUtils.ts
+++ b/packages/cli/src/common/utils/directoryUtils.ts
@@ -2,6 +2,7 @@ import fg from "fast-glob"
 import fs from "fs-extra"
 import { loadConfig } from "tsconfig-paths"
 import path from "path"
+import { ConfigError } from "../error"
 
 export function getTsConfigAlias(cwd: string, styledSytemPath: string) {
   const tsConfig = loadConfig(cwd)
@@ -42,9 +43,20 @@ export function getTsConfigAlias(cwd: string, styledSytemPath: string) {
   return { baseAlias, styledSystemAlias }
 }
 //panda.config.ts파일 찾기 -> 여기서 outdir이 현재 저장경로(없으면 styled-system)
-export async function getPandacssConfigFile(cwd: string) {
-  const files = await fg.glob(["panda.config.*"], { cwd, deep: 3 })
-  return files.length ? files[0] : null
+export async function getPandacssConfigPath(cwd: string) {
+  try {
+    const files = await fg.glob(["panda.config.*"], { cwd, deep: 3 })
+    if (!files.length) {
+      throw new ConfigError(`Panda CSS config file not found in ${cwd}`, {
+        cause: "File Not Found",
+      })
+    }
+    return files[0]
+  } catch (error) {
+    throw new ConfigError(`Failed to find Panda CSS config file in ${cwd}`, {
+      cause: error,
+    })
+  }
 }
 
 export async function resolvePandaConfig(config: string) {

--- a/packages/cli/src/init/index.ts
+++ b/packages/cli/src/init/index.ts
@@ -1,7 +1,7 @@
 import { packageDirectory } from "pkg-dir"
 import { checkJsonInit } from "./utils/checkJsonInit"
 import {
-  getPandacssConfigFile,
+  getPandacssConfigPath,
   getTsConfigAlias,
   resolvePandaConfig,
 } from "../common/utils/directoryUtils"
@@ -59,11 +59,7 @@ export async function init(options: z.infer<typeof initSchema>) {
   //   throw new Error("install pandacss")
   // }
 
-  const pandacssConfigPath = await getPandacssConfigFile(root)
-
-  if (!pandacssConfigPath) {
-    throw new Error("Failed to resolve pandacss config file")
-  }
+  const pandacssConfigPath = await getPandacssConfigPath(root)
 
   const pandacssConfigFile = await fs.readFile(
     path.resolve(root, pandacssConfigPath),

--- a/packages/cli/src/init/utils/checkPandaInit.ts
+++ b/packages/cli/src/init/utils/checkPandaInit.ts
@@ -1,6 +1,6 @@
 import fs from "fs-extra"
 import path from "path"
-import { getPandacssConfigFile } from "../../common/utils/directoryUtils"
+import { getPandacssConfigPath } from "../../common/utils/directoryUtils"
 
 const panda = "@pandacss/dev"
 
@@ -17,7 +17,7 @@ export async function checkPandaInit(cwd: string) {
   const isInstalled =
     Object.keys(devDeps).includes(panda) || Object.keys(deps).includes(panda) //panda가 devDependencies나 dependencies에 있는지 확인
 
-  const pandaConfig = await getPandacssConfigFile(cwd)
+  const pandaConfig = await getPandacssConfigPath(cwd)
 
   return isInstalled && !!pandaConfig
 }

--- a/packages/cli/src/test/add.test.ts
+++ b/packages/cli/src/test/add.test.ts
@@ -1,9 +1,9 @@
 import path from "path"
-import { test, vi, describe, beforeAll, afterAll } from "vitest"
+import { test, vi, describe, beforeAll, expect, afterAll } from "vitest"
 import fs from "fs-extra"
 import { addCommand } from "../add"
 
-const BUTTON_JSON = `{
+const BUTTON_JSON = {
   name: "button",
   dependencies: ["@radix-ui/react-slot"],
   files: [
@@ -17,11 +17,10 @@ const BUTTON_JSON = `{
       name: "recipe.ts",
       content:
         'import { defineSafe } from "@utils/defineSafe"\n\nexport const buttonRecipe = defineSafe.recipe({\n  className: "button",\n  description: "Styles for the Button component",\n  base: {\n    display: "inline-flex",\n    alignItems: "center",\n    justifyContent: "center",\n    rounded: "md",\n    textStyle: "sm",\n    fontWeight: "medium",\n    transition: "colors",\n    cursor: "pointer",\n    gap: "2",\n    _focusVisible: {\n      ringWidth: "1",\n      ringColor: "ring",\n      ringOffset: "1",\n    },\n\n    _disabled: {\n      cursor: "not-allowed",\n      opacity: "50%",\n    },\n  },\n  variants: {\n    variant: {\n      default: {\n        bg: "primary",\n        color: "primary.foreground",\n\n        _hover: {\n          bg: "primary/90",\n        },\n      },\n      destructive: {\n        bg: "destructive",\n        color: "destructive.foreground",\n\n        _hover: {\n          bg: "destructive/90",\n        },\n      },\n      outline: {\n        border: "input",\n        bg: "background",\n\n        _hover: {\n          bg: "accent",\n          color: "accent.foreground",\n        },\n      },\n      secondary: {\n        bg: "secondary",\n        color: "secondary.foreground",\n\n        _hover: {\n          bga: "secondary/90",\n        },\n      },\n      ghost: {\n        _hover: {\n          bg: "accent",\n          color: "accent.foreground",\n        },\n      },\n      link: {\n        color: "primary",\n        textUnderlineOffset: "4px",\n\n        _hover: {\n          textDecoration: "underline",\n        },\n      },\n    },\n    size: {\n      default: {\n        h: "10",\n        px: "4",\n        py: "2",\n      },\n      sm: {\n        h: "9",\n        rounded: "md",\n        px: "3",\n      },\n      lg: {\n        h: "11",\n        rounded: "md",\n        px: "8",\n      },\n      icon: {\n        h: "10",\n        w: "10",\n      },\n    },\n  },\n  defaultVariants: {\n    variant: "default",\n    size: "default",\n  },\n})\n',
-      typimport { fs } from 'fs-extra';
-e: "ui",
+      type: "ui",
     },
   ],
-}`
+}
 
 const PACKAGE_JSON = {
   devDependencies: {
@@ -31,10 +30,11 @@ const PACKAGE_JSON = {
 
 const TS_CONFIG = {
   compilerOptions: {
+    baseUrl: "src",
     paths: {
-      "@/*": ["./src/"],
-      "@styled-system/*": ["./styled-system/"],
-      "@utils/*": ["./src/utils/"],
+      "@/*": ["./*"],
+      "@styled-system/*": ["../styled-system/*"],
+      // "@utils/*": ["./src/utils/"],
     },
   },
 }
@@ -84,43 +84,65 @@ const PANDA_CONFIG_TS = `export default defineConfig({
 `
 
 describe("add test", () => {
-  const temp = path.join(__dirname, "../temp-add")
+  const temp = path.join(__dirname, "../../../temp-add")
+
   beforeAll(async () => {
     await fs.mkdir(temp, { recursive: true })
-    await fs.writeFile(
-      path.resolve(temp, "tsconfig.json"),
-      JSON.stringify(TS_CONFIG, null, 2),
-      "utf-8",
-    )
-    await fs.writeFile(
-      path.resolve(temp, "package.json"),
-      JSON.stringify(PACKAGE_JSON, null, 2),
-      "utf-8",
-    )
-    await fs.writeFile(
-      path.resolve(temp, "panda.config.ts"),
-      PANDA_CONFIG_TS,
-      "utf-8",
-    )
-    await fs.writeFile(
-      path.resolve(temp, "components.json"),
-      JSON.stringify(COMPONENTS_JSON, null, 2),
-      "utf-8",
-    )
-    await fs.writeFile(path.resolve(temp, "preset.ts"), PRESET_TS, "utf-8")
+    await Promise.all([
+      fs.writeFile(
+        path.resolve(temp, "tsconfig.json"),
+        JSON.stringify(TS_CONFIG, null, 2),
+        "utf-8",
+      ),
+      fs.writeFile(
+        path.resolve(temp, "package.json"),
+        JSON.stringify(PACKAGE_JSON, null, 2),
+        "utf-8",
+      ),
+      fs.writeFile(
+        path.resolve(temp, "panda.config.ts"),
+        PANDA_CONFIG_TS,
+        "utf-8",
+      ),
+      fs.writeFile(
+        path.resolve(temp, "components.json"),
+        JSON.stringify(COMPONENTS_JSON, null, 2),
+        "utf-8",
+      ),
+      fs.writeFile(path.resolve(temp, "preset.ts"), PRESET_TS, "utf-8"),
+      //folder
+      fs.mkdir(path.join(temp, "src", "components"), {
+        recursive: true,
+      }),
+      fs.mkdir(path.join(temp, "src", "utils"), { recursive: true }),
+      fs.mkdir(path.join(temp, "src", "hooks"), { recursive: true }),
+      fs.mkdir(path.join(temp, "styled-system"), { recursive: true }),
+    ])
   })
 
   afterAll(async () => {
     await fs.remove(temp)
   })
 
-  test("add", async () => {
+  test("터미널에 add button을 입력했을 경우 ./src/components 경로에 폴더가 생성된다", async () => {
     global.fetch = vi.fn(
       () =>
         Promise.resolve({
+          ok: true,
           json: () => Promise.resolve(BUTTON_JSON),
         }) as Promise<Response>,
     )
-    addCommand.parse(["add", "button", "-c", temp])
+    await addCommand.parseAsync(["node", "add", "button", "-c", temp])
+
+    expect(
+      fs.pathExistsSync(
+        path.join(temp, "src", "components", "button", "index.tsx"),
+      ),
+    ).toBeTruthy()
+    expect(
+      fs.pathExistsSync(
+        path.join(temp, "src", "components", "button", "recipe.ts"),
+      ),
+    ).toBeTruthy()
   })
 })

--- a/packages/cli/src/test/add.test.ts
+++ b/packages/cli/src/test/add.test.ts
@@ -85,10 +85,8 @@ const PANDA_CONFIG_TS = `export default defineConfig({
 
 describe("add test", () => {
   const temp = path.join(__dirname, "../temp-add")
-
   beforeAll(async () => {
     await fs.mkdir(temp, { recursive: true })
-
     await fs.writeFile(
       path.resolve(temp, "tsconfig.json"),
       JSON.stringify(TS_CONFIG, null, 2),
@@ -123,7 +121,6 @@ describe("add test", () => {
           json: () => Promise.resolve(BUTTON_JSON),
         }) as Promise<Response>,
     )
-    process.chdir(temp)
     addCommand.parse(["add", "button", "-c", temp])
   })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,6 +156,9 @@ importers:
       '@types/babel__traverse':
         specifier: ^7.20.6
         version: 7.20.6
+      chalk:
+        specifier: ^5.4.1
+        version: 5.4.1
       commander:
         specifier: ^13.0.0
         version: 13.0.0
@@ -3325,6 +3328,10 @@ packages:
 
   chalk@5.3.0:
     resolution: {integrity: sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  chalk@5.4.1:
+    resolution: {integrity: sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
   change-case@3.1.0:
@@ -10577,6 +10584,8 @@ snapshots:
       supports-color: 7.2.0
 
   chalk@5.3.0: {}
+
+  chalk@5.4.1: {}
 
   change-case@3.1.0:
     dependencies:


### PR DESCRIPTION
## ✨ 설명
- add 명령에 대한 에러 핸들링 로직을 추가
## 🔍 주요 변경 사항
- [ ] `Zod`  라이브러리를 참고해서, 새로운 에러 핸들링 process를 만들어봄
- [ ]

## ✅ 테스트 결과

## 📌 참고 사항
1. 어떻게 에러를 나눌지?
- 모든 에러를 throw Error()로 하게 되면 어디에서 어떤 에러가 발생했는지 바로 알기 어렵다고 판단. 뭔가 섹션이 나뉘어있어서 - 어떤 섹션에서 발생했는지를 알려주는 게 더 유용할 것 같음
- 섹션을 어떻게 나눌지? 특정 파일별로 나눌수도 있겠지만, 그렇게 되면 너무 많은 경우의수가 생김
- 특정 행위(config,path resolve,fetch) 등으로 나누어 관리하는 게 유용하겠다 판단

- 에러 핸들링 로직
issue에 적어놓은 에러 유형별로 각각의 에러 객체를 만들고, 에러 발생시 or 에러에 준하는 상황 발생 시 해당 에러객체를 throw하는 방식으로 접근하려 시도([cddb058](https://github.com/jongh-design-system/j-design-system/pull/100/commits/cddb0583ec1e225a91308b92d998f049b8fdf7bc))
-> 각각의 에러 객체가 독립적으로 interface를 가지게 되는데, catch절에서는 동일한 format으로 한번에 에러메시지를 출력할 수 있게 하는 등 공통적인 interface 부분도 필요함 
-> 이 부분이 조금 애매하다고 판단(에러객체를 extends하는 custom 에러객체를 하나 더 만들어서, 공통적으로 필요한 interface를 선언한 뒤 각 에러객체들이 이를 extends해서 사용하는 것도 가능)

-> `Zod` 를 참고하여 multiple issue - error 방식으로 선언
- Zod의 경우 `ZodError` 라는 하나의 에러객체만 throw되는데, 이 에러객체의 인자로 들어가는 `issue` 를 통해 어떠한 상황에서 에러가 발생했는지를 관리
- 현재 내가 각각의 에러객체로 만들고 있는 걸 여기서는 issue로, interface(type)으로 관리하고 있다고 보면 됨
- Zod의 경우 하나의 함수에 여러 에러사항들이 발생할 수 있기 때문에 여러 issue들을 모아놓는 처리가 되어있음

- 타입을 사용하여 이슈 코드, 이슈 interface를 선언
- 이슈에 따라 메시지 및 에러 throw를 한번에 관리하기 위해 ErrorMap 사용 [6b2de56](https://github.com/jongh-design-system/j-design-system/pull/100/commits/6b2de562b291afdb99c68d66884e3ad3eada19c6)

장점
- 에러 처리 프로세스가 고정됨
에러가 발생할 상황이다 - 타입에 맞게 issue를 생성하고, ErrorMap의 인자로 전달만 하면 됨
단점
- 사용법 미숙으로 불필요한 타입이나 상황들이 존재
- 내가 임의로 에러를 throw해도 되는건지?
- 만약에 내가 임의로 에러를 throw하는 상황이 아니라, 기존 에러 객체가 존재할 경우 이 에러객체를 어디까지 이용해야 할지? 