### PR TITLE
storybook chromatic 배포 자동화

### DIFF
--- a/.github/actions/aws/action.yml
+++ b/.github/actions/aws/action.yml
@@ -1,0 +1,35 @@
+name: "AWS Deploy"
+description: "Configures AWS credentials and deploys to S3, then invalidates CloudFront cache."
+inputs:
+  aws_role_to_assume:
+    description: "The ARN of the AWS role to assume."
+    required: true
+  aws_region:
+    description: "The AWS region."
+    required: true
+  aws_s3_bucket_name:
+    description: "The name of the S3 bucket."
+    required: true
+  aws_cloudfront_id:
+    description: "The ID of the CloudFront distribution."
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      shell: bash
+      with:
+        role-to-assume: ${{ inputs.aws_role_to_assume }}
+        role-session-name: "deploy"
+        aws-region: ${{ inputs.aws_region }}
+    - name: Deploy to S3
+      shell: bash
+      run: aws s3 sync ./app/docs/out s3://${{ inputs.aws_s3_bucket_name }} --delete
+
+    - name: Invalidate CloudFront Cache
+      shell: bash
+      run: |
+        aws cloudfront create-invalidation \
+          --distribution-id ${{ inputs.aws_cloudfront_id }} \
+          --paths '/*'

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -23,9 +23,9 @@ jobs:
       - name: build
         run: pnpm turbo build
 
-      - name: Deploy to AWS
-
+      - name: deploy to AWS
         uses: ./.github/actions/deploy
+        if: contains(github.event.head_commit.message,'app/docs')
         with:
           aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws_region: ${{ secrets.AWS_REGION }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,10 +2,7 @@ name: Build & Deploy Docs
 permissions:
   id-token: write
   contents: read
-on:
-  push:
-    branches:
-      - dev
+on: workflow_dispatch
 env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   TURBO_TEAM: ${{ vars.TURBO_TEAM }}
@@ -31,3 +28,12 @@ jobs:
           aws_region: ${{ secrets.AWS_REGION }}
           aws_s3_bucket_name: ${{ secrets.AWS_S3_BUCKET_NAME }}
           aws_cloudfront_id: ${{ secrets.AWS_CLOUDFRONT_ID }}
+
+      - name: deploy storybook to chromatic
+        uses: chromaui/action@latest
+        # Options required for Chromatic's GitHub Action
+        with:
+          #👇 Chromatic projectToken, see https://storybook.js.org/tutorials/intro-to-storybook/react/ko/deploy/ to obtain it
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          workingDir: packages/ui

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -23,18 +23,11 @@ jobs:
       - name: build
         run: pnpm turbo build
 
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+      - name: Deploy to AWS
+
+        uses: ./.github/actions/deploy
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          role-session-name: "deploy"
-          aws-region: ${{ secrets.AWS_REGION }}
-
-      - name: Deploy to S3
-        run: aws s3 sync ./app/docs/out s3://${{ secrets.AWS_S3_BUCKET_NAME }} --delete
-
-      - name: Invalidate CloudFront Cache
-        run: |
-          aws cloudfront create-invalidation \
-            --distribution-id ${{secrets.AWS_CLOUDFRONT_ID}} \
-            --paths "/*"
+          aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws_region: ${{ secrets.AWS_REGION }}
+          aws_s3_bucket_name: ${{ secrets.AWS_S3_BUCKET_NAME }}
+          aws_cloudfront_id: ${{ secrets.AWS_CLOUDFRONT_ID }}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -9,7 +9,7 @@
     "test": "vitest run",
     "test-storybook": "vitest",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build",
+    "build": "storybook build",
     "check-type": "tsc --noEmit"
   },
   "dependencies": {

--- a/turbo.json
+++ b/turbo.json
@@ -2,7 +2,7 @@
   "$schema": "https://turbo.build/schema.json",
   "tasks": {
     "build": {
-      "outputs": ["dist/**", ".next/**", "out/**"],
+      "outputs": ["dist/**", ".next/**", "out/**", "storybook-static/**"],
       "dependsOn": ["^build"]
     },
     "docs#build": {


### PR DESCRIPTION
## ✨ 설명
- github actions를 통해 storybook을 chromatic을 통해 배포
## 🔍 주요 변경 사항
- [ ] 기존의 aws 배포와 chromatic 배포 과정을 composite action으로 분리한뒤 적용 [e6e10a7](https://github.com/jongh-design-system/j-design-system/pull/107/commits/e6e10a7a3dfc781ece2f67a258cb74f4fbaa4df6) [38ad38d](https://github.com/jongh-design-system/j-design-system/pull/107/commits/38ad38d56b5dc0346f84893a62168b3cdc155ac6)
- [ ] storybook 빌드를 위한 turbo 설정 일부 변경 [790212d](https://github.com/jongh-design-system/j-design-system/pull/107/commits/790212d4645478b686866094ab95c517955d532e)

## ✅ 테스트 결과

## 📌 참고 사항
- `chromaui/action` 이라는 패키지에서 자동으로 build-storybook이라는 script를 실행해서 빌드 + 배포를 담당하고 있는데, 기존의 action 코드에서는 그 전에 turbo build를 통해 빌드를  한번 진행하고 있음(기존에 ui는 빌드 진행 X - 필요없어서)
- build-storybook이라는 스토리북 빌드를 위한 스크립트를 turbo로 진행하려면 추가적인 설정이 또 필요하고, 순서라던가 하는 부분을 신경써야 함
- 어차피 기존에 `ui` 에서 빌드를 안한다면, 그냥 `ui` 의 build script에서 storybook build를 실행하면 어떨까? - turbo.json의 output에만 신경써주면 됨