### PR TITLE
init 기능 개선

### DIFF
--- a/.changeset/odd-waves-smoke.md
+++ b/.changeset/odd-waves-smoke.md
@@ -1,0 +1,5 @@
+---
+"@jongh/cli": minor
+---
+
+improve resolving alias and handling error

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -9,7 +9,7 @@
     "build:cli": "tsup",
     "build:registry": "npx tsx ./src/build-script.ts --all",
     "release": "pnpm publish -no-git-checks",
-    "lint": "eslint --max-warnings 0 --fix",
+    "lint": "eslint --max-warnings 0 --no-warn-ignored --fix",
     "check-type": "tsc --noEmit",
     "test": "vitest run"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -23,6 +23,9 @@
     "dist",
     "package.json"
   ],
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "dependencies": {
     "@babel/generator": "^7.26.3",
     "@babel/parser": "^7.26.3",

--- a/packages/cli/src/commands/add/index.ts
+++ b/packages/cli/src/commands/add/index.ts
@@ -14,9 +14,8 @@ import {
   getPandacssConfigPath,
   loadComponentConfig,
   loadTSConfig,
-  resolvePandaConfig,
 } from "@/common/get-config"
-import { resolveImport } from "@/common/resolve"
+import { resolveImport, resolvePandaConfig } from "@/common/resolve"
 import { transformImports, transformPreset } from "@/common/transform"
 import { configSchema, registrySchema } from "@/common/types"
 import { getPackageManagerRunner } from "@/common/utils/packageManager"

--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -3,11 +3,12 @@ import { Command } from "commander"
 import fs from "fs-extra"
 import path from "path"
 import { packageDirectory } from "pkg-dir"
-import { type ObjectLiteralExpression, Project, SyntaxKind } from "ts-morph"
 import { z } from "zod"
 
 import { checkJsonInit, getTsConfigAlias } from "@/common/get-config"
-import { getPandacssConfigPath, resolvePandaConfig } from "@/common/get-config"
+import { getPandacssConfigPath } from "@/common/get-config"
+import { resolvePandaConfig } from "@/common/resolve"
+import { transformPandaConfig } from "@/common/transform"
 import { configSchema, type ConfigType } from "@/common/types"
 import { fetchPreset } from "@/common/utils/fetchRegistry"
 
@@ -58,7 +59,6 @@ export async function init(options: z.infer<typeof initSchema>) {
   }
 
   const pandacssConfigPath = await getPandacssConfigPath(root)
-
   const pandacssConfigFile = await fs.readFile(
     path.join(root, pandacssConfigPath),
     "utf-8",
@@ -127,7 +127,7 @@ export async function init(options: z.infer<typeof initSchema>) {
   fs.writeFile(path.join(root, preset.name), JSON.parse(preset.file))
 
   //modify panda.config.ts
-  modifyPandaConfig(path.resolve(root, pandacssConfigPath))
+  transformPandaConfig(path.resolve(root, pandacssConfigPath))
 
   await fs.writeFile(
     path.resolve(root, "components.json"),
@@ -136,51 +136,4 @@ export async function init(options: z.infer<typeof initSchema>) {
   )
 
   return config
-}
-
-function modifyPandaConfig(path: string) {
-  const project = new Project()
-  const sourceFile = project.addSourceFileAtPath(path)
-
-  const importToIncludes = [
-    {
-      namedImports: [{ name: "preset" }],
-      moduleSpecifier: "panda-animation",
-    },
-    {
-      namedImports: [{ name: "defaultPreset" }],
-      moduleSpecifier: "./preset",
-    },
-  ]
-
-  sourceFile.addImportDeclarations(importToIncludes)
-
-  //export defineConfig() 형식으로 사용한 경우에만 가능
-  const defineConfigCall = sourceFile.getFirstDescendantByKind(
-    SyntaxKind.CallExpression,
-  )
-  // 설정 객체 가져오기
-  const configObject =
-    defineConfigCall?.getArguments()[0] as ObjectLiteralExpression
-
-  //panda.config.ts파일에 presets에 추가하기
-  if (configObject) {
-    // presets 속성이 이미 있는지 확인
-    const existingPresets = configObject.getProperty("presets")
-
-    if (!existingPresets) {
-      // presets 속성이 없다면 추가
-      configObject.addPropertyAssignment({
-        name: "presets",
-        initializer: `[preset(), "@pandacss/preset-panda", defaultPreset"]`,
-      })
-    }
-
-    // 변경사항 저장
-    sourceFile.saveSync()
-  } else {
-    console.warn(
-      "Could not modify panda.config.ts. add presets : [preset(), @pandacss/preset-panda, defaultPreset] in your panda.config",
-    )
-  }
 }

--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -5,11 +5,11 @@ import path from "path"
 import { packageDirectory } from "pkg-dir"
 import { z } from "zod"
 
-import { checkJsonInit, getTsConfigAlias } from "@/common/get-config"
+import { checkJsonInit, getBaseAlias, getStyleAlias } from "@/common/get-config"
 import { getPandacssConfigPath } from "@/common/get-config"
 import { resolvePandaConfig } from "@/common/resolve"
 import { transformPandaConfig } from "@/common/transform"
-import { configSchema, type ConfigType } from "@/common/types"
+import { configSchema } from "@/common/types"
 import { fetchPreset } from "@/common/utils/fetchRegistry"
 
 const initSchema = z.object({
@@ -64,69 +64,37 @@ export async function init(options: z.infer<typeof initSchema>) {
     "utf-8",
   )
 
-  // const project = new Project()
-  // project.addSourceFileAtPath(pandacssConfigPath)
-  // const sourceFile = project.getSourceFileOrThrow(pandacssConfigPath)
-
-  // const defineCofigExpression = sourceFile
-  //   .getDescendantsOfKind(SyntaxKind.CallExpression)
-  //   .filter((v) => v.getExpression().getText() === "defineConfig")[0]
-
-  // const object = defineCofigExpression.getChildrenOfKind(
-  //   SyntaxKind.ObjectLiteralExpression,
-  // )[0]
-
-  // for (const property of object.getProperties()) {
-  //   if (property.getText().startsWith("outdir")) {
-  //     return property.getText().split(":")[1].replace(/"/g, "")
-  //   }
-  // }
-
-  //styled-system은 상대경로가 어떻게 되어있나만 체크하면 됨
-  //outdir 속성이 없으면 default로 styled-system으로 지정되어있음 -> 이 경로에 해당하는 tsconfig alias를 찾아야함
-  //outdir 속성이 있으면 -> 해당 값의 경로에 해당하는 tsconfig alias를 찾아야함
-  //importMap 속성이 있으면 -> 해당 값 그대로 사용
-  //string일수도 , object일수도 있음
-  //string이면 -> 그대로 사용
-  //object면 -> css라는 속성값만 찾아서 사용
-
   let defaultStyledSystemAlias = "styled-system"
 
-  const { outdir, importMap } = await resolvePandaConfig(pandacssConfigFile) //outdir와 importMap이 있는지
+  const { outdir, importMap } = await resolvePandaConfig(pandacssConfigFile)
+  // outdir은 생성된 파일들이 저장될 디렉토리를 지정하는 옵션이고,
+  // importMap은 그 디렉토리를 애플리케이션 코드에서 어떻게 import할지 경로를 매핑하는 역할
 
+  //만약 importMap이 있으면 그 값을 그대로 사용
+  if (importMap) {
+    defaultStyledSystemAlias = importMap
+  } else {
+    //존재하지 않을 경우 - outdir || styled-system으로 되어있는 alias를 찾아본 뒤
+    defaultStyledSystemAlias =
+      getStyleAlias(root, outdir || "styled-system") || "." //없다면 현재 디렉토리의 root경로에 있다고 가정(.)
+  }
   if (outdir) {
     defaultStyledSystemAlias = outdir //outdir이 있으면 경로는 outdir
   }
 
-  const { baseAlias, styledSystemAlias } = getTsConfigAlias(
-    root,
-    defaultStyledSystemAlias,
-  ) //tsconfig에 접근해서 찾아내기
+  const baseAlias = getBaseAlias(root)
 
-  if (!baseAlias || !styledSystemAlias) {
-    throw new Error("Failed to find tsconfig alias")
-  }
-
-  if (importMap) {
-    defaultStyledSystemAlias = importMap //importMap이 있으면 그대로 사용
-  } else {
-    defaultStyledSystemAlias = styledSystemAlias //importMap이 없으면 찾은 값 사용
-  }
-
-  const config = {
+  const config = configSchema.schema.parse({
     utils: `${baseAlias}/utils`,
     components: `${baseAlias}/components`,
     hooks: `${baseAlias}/hooks`,
     styledsystem: defaultStyledSystemAlias,
-  } satisfies ConfigType
-
-  configSchema.schema.parse(config)
+  })
 
   const preset = await fetchPreset()
 
   fs.writeFile(path.join(root, preset.name), JSON.parse(preset.file))
 
-  //modify panda.config.ts
   transformPandaConfig(path.resolve(root, pandacssConfigPath))
 
   await fs.writeFile(

--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -5,7 +5,13 @@ import path from "path"
 import { packageDirectory } from "pkg-dir"
 import { z } from "zod"
 
-import { checkJsonInit, getBaseAlias, getStyleAlias } from "@/common/get-config"
+import { CommandError, ErrorMap } from "@/common/error"
+import {
+  checkJsonInit,
+  getBaseAlias,
+  getStyleAlias,
+  loadTSConfig,
+} from "@/common/get-config"
 import { getPandacssConfigPath } from "@/common/get-config"
 import { resolvePandaConfig } from "@/common/resolve"
 import { transformPandaConfig } from "@/common/transform"
@@ -32,10 +38,10 @@ export const initCommand = new Command()
         cwd: path.resolve(opts.cwd),
       })
       await init(options)
-      s.stop("Initialized")
+      s.stop("successfully Initialized!")
     } catch (e) {
-      if (e instanceof Error) {
-        console.error(e.message)
+      if (e instanceof CommandError) {
+        console.error(e.format)
       }
       s.stop("Failed to initialize")
       process.exit(0)
@@ -45,8 +51,14 @@ export const initCommand = new Command()
 export async function init(options: z.infer<typeof initSchema>) {
   const root = options.cwd || (await packageDirectory()) //뒤에꺼 절대 실행안되고 있음
   if (!root) {
-    throw new Error("Failed to find package root")
+    throw ErrorMap({
+      code: "config_not_found",
+      configFile: "package.json",
+      message: [`cannot find package.json in ${root}`],
+    })
   }
+
+  const result = loadTSConfig(root)
 
   const isInitialize = await checkJsonInit(root)
   if (isInitialize) {
@@ -64,6 +76,8 @@ export async function init(options: z.infer<typeof initSchema>) {
     "utf-8",
   )
 
+  const baseAlias = getBaseAlias(root, result)
+
   let defaultStyledSystemAlias = "styled-system"
 
   const { outdir, importMap } = await resolvePandaConfig(pandacssConfigFile)
@@ -76,13 +90,11 @@ export async function init(options: z.infer<typeof initSchema>) {
   } else {
     //존재하지 않을 경우 - outdir || styled-system으로 되어있는 alias를 찾아본 뒤
     defaultStyledSystemAlias =
-      getStyleAlias(root, outdir || "styled-system") || "." //없다면 현재 디렉토리의 root경로에 있다고 가정(.)
+      getStyleAlias(root, outdir || "styled-system", result) || "." //없다면 현재 디렉토리의 root경로에 있다고 가정(.)
   }
   if (outdir) {
     defaultStyledSystemAlias = outdir //outdir이 있으면 경로는 outdir
   }
-
-  const baseAlias = getBaseAlias(root)
 
   const config = configSchema.schema.parse({
     utils: `${baseAlias}/utils`,

--- a/packages/cli/src/common/get-config/index.ts
+++ b/packages/cli/src/common/get-config/index.ts
@@ -1,7 +1,7 @@
 import fg from "fast-glob"
 import fs from "fs-extra"
 import path from "path"
-import { loadConfig } from "tsconfig-paths"
+import { type ConfigLoaderSuccessResult, loadConfig } from "tsconfig-paths"
 
 import { ErrorMap } from "../error"
 import { configSchema } from "../types"
@@ -20,7 +20,7 @@ export function loadComponentConfig(cwd: string) {
 
 // tsConfig 읽기 전용
 // loadConfig는 현재 디렉토리에 tsconfig가 없으면 경로를 내려가서 tsconfig를 찾는걸로 보임
-export async function loadTSConfig(cwd: string) {
+export function loadTSConfig(cwd: string) {
   const tsconfig = loadConfig(cwd)
   if (tsconfig.resultType === "failed") {
     throw ErrorMap({
@@ -53,96 +53,47 @@ export async function checkPandaInit(cwd: string) {
   return isInstalled && !!pandaConfig
 }
 
-// export function getTsConfigAlias(cwd: string, styledSytemPath: string) {
-//   //현재 styledSystemPath -> 즉 styled-system 역할을 하는 파일이 tsconfig에서 어떤 alias로 지정되어있는지 확인
-//   //추가로 tsconfig의 base alias도 확인
-//   const tsConfig = loadConfig(cwd)
-
-//   if (
-//     tsConfig?.resultType === "failed" ||
-//     !Object.entries(tsConfig?.paths).length
-//   ) {
-//     return { baseAlias: null, styledSystemAlias: null }
-//   }
-
-//   let baseAlias = null
-//   let styledSystemAlias = null
-
-//   // 모든 alias 순회하면서 둘 다 찾기
-//   for (const [alias, paths] of Object.entries(tsConfig.paths)) {
-//     // styled-system alias 찾기 - paths 경로 문자열에 포함되어있으면 styled-system alias라고 판단
-//     if (paths[0].includes(styledSytemPath)) {
-//       styledSystemAlias = alias.replace(/\/\*$/, "")
-//     }
-
-//     // base alias 찾기
-//     if (
-//       paths.includes("./*") ||
-//       paths.includes("./src/*") ||
-//       paths.includes("./app/*")
-//     ) {
-//       baseAlias = alias.replace(/\/\*$/, "")
-//     }
-//   }
-//   if (!baseAlias) {
-//     baseAlias = Object.keys(tsConfig?.paths)?.[0].replace(/\/\*$/, "") ?? null
-//   }
-//   if (!styledSystemAlias) {
-//     styledSystemAlias = "."
-//   }
-
-//   return { baseAlias, styledSystemAlias }
-// }
-
-export function getBaseAlias(cwd: string) {
-  const tsConfig = loadConfig(cwd)
-
-  if (
-    tsConfig?.resultType === "failed" ||
-    !Object.entries(tsConfig?.paths).length
-  ) {
-    return null
-  }
-
-  let baseAlias = null
+export function getBaseAlias(cwd: string, tsConfig: ConfigLoaderSuccessResult) {
+  const basePaths = ["./", "./src/", "./app/", "./src/app"].map((p) =>
+    path.resolve(cwd, p),
+  )
 
   for (const [alias, paths] of Object.entries(tsConfig.paths)) {
+    const resolvedPaths = path.join(
+      cwd,
+      tsConfig.baseUrl || "",
+      paths[0].replace(/\/\*$/, ""),
+    )
+
     if (
-      paths.includes("./*") ||
-      paths.includes("./src/*") ||
-      paths.includes("./app/*")
+      basePaths.some((p) => p === resolvedPaths || p.includes(resolvedPaths))
     ) {
-      baseAlias = alias.replace(/\/\*$/, "")
+      return alias.replace(/\/\*$/, "")
     }
   }
 
-  return baseAlias
+  return null
 }
+//outdir을 설정하면
+//outdir의 경로는 process.cwd+outdir
+export function getStyleAlias(
+  cwd: string,
+  styleFolderName: string,
+  tsConfig: ConfigLoaderSuccessResult,
+) {
+  // outdir를 절대 경로로 변환
+  const targetOutdir = path.join(cwd, styleFolderName) //styleForderName이 절대경로일 수도 있음
 
-export function getStyleAlias(cwd: string, styleForderName: string) {
-  const tsConfig = loadConfig(cwd)
-
-  if (
-    tsConfig?.resultType === "failed" ||
-    !Object.entries(tsConfig?.paths).length
-  ) {
-    return null
-  }
-  let styledAlias: string | null = null
-
-  // 각 alias의 첫 번째 경로를 확인하여 styledSystemPath가 포함되었는지 체크
   for (const [alias, paths] of Object.entries(tsConfig.paths)) {
-    if (paths[0].includes(styleForderName)) {
-      styledAlias = alias.replace(/\/\*$/, "")
-      break
+    const normalizedPath = paths[0].replace(/\/\*$/, "")
+    if (
+      targetOutdir === path.join(cwd, tsConfig.baseUrl || "", normalizedPath)
+    ) {
+      return alias.replace(/\/\*$/, "")
     }
   }
 
-  // if (!styledAlias) {
-  //   styledAlias = "."
-  // }
-
-  return styledAlias
+  return null
 }
 
 export async function getPandacssConfigPath(cwd: string) {

--- a/packages/cli/src/common/get-config/index.ts
+++ b/packages/cli/src/common/get-config/index.ts
@@ -115,23 +115,3 @@ export async function getPandacssConfigPath(cwd: string) {
     })
   }
 }
-
-export async function resolvePandaConfig(config: string) {
-  const outdirMatch = config.match(/outdir:\s*["']([^"']+)["']/)
-  const importMapMatch = config.match(/importMap:\s*({[^}]+}|["'][^"']+["'])/)
-
-  const outdir = outdirMatch ? outdirMatch[1] : null
-  let importMap = null
-
-  if (importMapMatch) {
-    const value = importMapMatch[1]
-    if (value.startsWith("{")) {
-      const cssMatch = value.match(/css:\s*["']([^"']+)["']/)
-      importMap = cssMatch ? cssMatch[1].replace(/\/css$/, "") : null
-    } else {
-      importMap = value.replace(/["']/g, "")
-    }
-  }
-
-  return { outdir, importMap }
-}

--- a/packages/cli/src/common/get-config/index.ts
+++ b/packages/cli/src/common/get-config/index.ts
@@ -53,27 +53,60 @@ export async function checkPandaInit(cwd: string) {
   return isInstalled && !!pandaConfig
 }
 
-export function getTsConfigAlias(cwd: string, styledSytemPath: string) {
+// export function getTsConfigAlias(cwd: string, styledSytemPath: string) {
+//   //현재 styledSystemPath -> 즉 styled-system 역할을 하는 파일이 tsconfig에서 어떤 alias로 지정되어있는지 확인
+//   //추가로 tsconfig의 base alias도 확인
+//   const tsConfig = loadConfig(cwd)
+
+//   if (
+//     tsConfig?.resultType === "failed" ||
+//     !Object.entries(tsConfig?.paths).length
+//   ) {
+//     return { baseAlias: null, styledSystemAlias: null }
+//   }
+
+//   let baseAlias = null
+//   let styledSystemAlias = null
+
+//   // 모든 alias 순회하면서 둘 다 찾기
+//   for (const [alias, paths] of Object.entries(tsConfig.paths)) {
+//     // styled-system alias 찾기 - paths 경로 문자열에 포함되어있으면 styled-system alias라고 판단
+//     if (paths[0].includes(styledSytemPath)) {
+//       styledSystemAlias = alias.replace(/\/\*$/, "")
+//     }
+
+//     // base alias 찾기
+//     if (
+//       paths.includes("./*") ||
+//       paths.includes("./src/*") ||
+//       paths.includes("./app/*")
+//     ) {
+//       baseAlias = alias.replace(/\/\*$/, "")
+//     }
+//   }
+//   if (!baseAlias) {
+//     baseAlias = Object.keys(tsConfig?.paths)?.[0].replace(/\/\*$/, "") ?? null
+//   }
+//   if (!styledSystemAlias) {
+//     styledSystemAlias = "."
+//   }
+
+//   return { baseAlias, styledSystemAlias }
+// }
+
+export function getBaseAlias(cwd: string) {
   const tsConfig = loadConfig(cwd)
 
   if (
     tsConfig?.resultType === "failed" ||
     !Object.entries(tsConfig?.paths).length
   ) {
-    return { baseAlias: null, styledSystemAlias: null }
+    return null
   }
 
   let baseAlias = null
-  let styledSystemAlias = null
 
-  // 모든 alias 순회하면서 둘 다 찾기
   for (const [alias, paths] of Object.entries(tsConfig.paths)) {
-    // styled-system alias 찾기 - paths 경로 문자열에 포함되어있으면 styled-system alias라고 판단
-    if (paths[0].includes(styledSytemPath)) {
-      styledSystemAlias = alias.replace(/\/\*$/, "")
-    }
-
-    // base alias 찾기
     if (
       paths.includes("./*") ||
       paths.includes("./src/*") ||
@@ -82,14 +115,34 @@ export function getTsConfigAlias(cwd: string, styledSytemPath: string) {
       baseAlias = alias.replace(/\/\*$/, "")
     }
   }
-  if (!baseAlias) {
-    baseAlias = Object.keys(tsConfig?.paths)?.[0].replace(/\/\*$/, "") ?? null
+
+  return baseAlias
+}
+
+export function getStyleAlias(cwd: string, styleForderName: string) {
+  const tsConfig = loadConfig(cwd)
+
+  if (
+    tsConfig?.resultType === "failed" ||
+    !Object.entries(tsConfig?.paths).length
+  ) {
+    return null
   }
-  if (!styledSystemAlias) {
-    styledSystemAlias = "."
+  let styledAlias: string | null = null
+
+  // 각 alias의 첫 번째 경로를 확인하여 styledSystemPath가 포함되었는지 체크
+  for (const [alias, paths] of Object.entries(tsConfig.paths)) {
+    if (paths[0].includes(styleForderName)) {
+      styledAlias = alias.replace(/\/\*$/, "")
+      break
+    }
   }
 
-  return { baseAlias, styledSystemAlias }
+  // if (!styledAlias) {
+  //   styledAlias = "."
+  // }
+
+  return styledAlias
 }
 
 export async function getPandacssConfigPath(cwd: string) {

--- a/packages/cli/src/common/get-config/index.ts
+++ b/packages/cli/src/common/get-config/index.ts
@@ -94,15 +94,15 @@ export function getTsConfigAlias(cwd: string, styledSytemPath: string) {
 
 export async function getPandacssConfigPath(cwd: string) {
   try {
-    const files = await fg.glob(["panda.config.*"], { cwd, deep: 3 })
-    if (!files.length) {
+    const paths = await fg.glob(["panda.config.*"], { cwd, deep: 3 })
+    if (!paths.length) {
       throw ErrorMap({
         code: "config_not_found",
         configFile: "panda.config.*",
         message: ["failed to find panda.config file"],
       })
     }
-    return files[0]
+    return paths[0]
   } catch (error) {
     throw ErrorMap({
       code: "config_not_found",

--- a/packages/cli/src/common/resolve/index.ts
+++ b/packages/cli/src/common/resolve/index.ts
@@ -33,3 +33,23 @@ export async function resolveAllPaths(
     styledsystem: await resolveImport(config.styledsystem, tsconfig),
   }
 }
+
+export async function resolvePandaConfig(config: string) {
+  const outdirMatch = config.match(/outdir:\s*["']([^"']+)["']/)
+  const importMapMatch = config.match(/importMap:\s*({[^}]+}|["'][^"']+["'])/)
+
+  const outdir = outdirMatch ? outdirMatch[1] : null
+  let importMap = null
+
+  if (importMapMatch) {
+    const value = importMapMatch[1]
+    if (value.startsWith("{")) {
+      const cssMatch = value.match(/css:\s*["']([^"']+)["']/)
+      importMap = cssMatch ? cssMatch[1].replace(/\/css$/, "") : null
+    } else {
+      importMap = value.replace(/["']/g, "")
+    }
+  }
+
+  return { outdir, importMap }
+}

--- a/packages/cli/src/common/resolve/index.ts
+++ b/packages/cli/src/common/resolve/index.ts
@@ -2,6 +2,7 @@ import { type ConfigLoaderSuccessResult, createMatchPath } from "tsconfig-paths"
 
 import { ErrorMap } from "@/common/error"
 import type { ConfigType } from "@/common/types"
+
 export async function resolveImport(
   importPath: string,
   config: Pick<ConfigLoaderSuccessResult, "absoluteBaseUrl" | "paths">,

--- a/packages/cli/src/common/transform/index.ts
+++ b/packages/cli/src/common/transform/index.ts
@@ -1,4 +1,9 @@
-import { Node, Project, SyntaxKind } from "ts-morph"
+import {
+  Node,
+  type ObjectLiteralExpression,
+  Project,
+  SyntaxKind,
+} from "ts-morph"
 
 import type { ConfigType } from "../types"
 
@@ -98,4 +103,51 @@ export function transformPreset(
 
   // 변경사항 저장
   sourceFile.saveSync()
+}
+
+export function transformPandaConfig(path: string) {
+  const project = new Project()
+  const sourceFile = project.addSourceFileAtPath(path)
+
+  const importToIncludes = [
+    {
+      namedImports: [{ name: "preset" }],
+      moduleSpecifier: "panda-animation",
+    },
+    {
+      namedImports: [{ name: "defaultPreset" }],
+      moduleSpecifier: "./preset",
+    },
+  ]
+
+  sourceFile.addImportDeclarations(importToIncludes)
+
+  //export defineConfig() 형식으로 사용한 경우에만 가능
+  const defineConfigCall = sourceFile.getFirstDescendantByKind(
+    SyntaxKind.CallExpression,
+  )
+  // 설정 객체 가져오기
+  const configObject =
+    defineConfigCall?.getArguments()[0] as ObjectLiteralExpression
+
+  //panda.config.ts파일에 presets에 추가하기
+  if (configObject) {
+    // presets 속성이 이미 있는지 확인
+    const existingPresets = configObject.getProperty("presets")
+
+    if (!existingPresets) {
+      // presets 속성이 없다면 추가
+      configObject.addPropertyAssignment({
+        name: "presets",
+        initializer: `[preset(), "@pandacss/preset-panda", defaultPreset"]`,
+      })
+    }
+
+    // 변경사항 저장
+    sourceFile.saveSync()
+  } else {
+    console.warn(
+      "Could not modify panda.config.ts. add presets : [preset(), @pandacss/preset-panda, defaultPreset] in your panda.config",
+    )
+  }
 }

--- a/packages/cli/src/test/fixture/init_test/package.json
+++ b/packages/cli/src/test/fixture/init_test/package.json
@@ -1,0 +1,5 @@
+{
+  "devDependencies": {
+    "@pandacss/dev": "^1.0.0"
+  }
+}

--- a/packages/cli/src/test/fixture/init_test/panda.config.ts
+++ b/packages/cli/src/test/fixture/init_test/panda.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "@pandacss/dev"
+
+export default defineConfig({
+  preflight: true,
+  include: ["./src/**/*.{ts,tsx,js,jsx}", "./pages/**/*.{ts,tsx,js,jsx}"],
+  outdir: "styled-system",
+})

--- a/packages/cli/src/test/fixture/init_test/tsconfig.json
+++ b/packages/cli/src/test/fixture/init_test/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/app/*"],
+      "fake/*": ["/a/b/c/d/*"],
+      "@styled-system/*": ["./styled-system/*"],
+      "@utils/*": ["./src/utils/*"]
+    }
+  }
+}

--- a/packages/cli/src/test/init.test.ts
+++ b/packages/cli/src/test/init.test.ts
@@ -1,94 +1,51 @@
 import fs from "fs-extra"
 import path from "path"
-import { afterAll, beforeAll, describe, expect, test, vi } from "vitest"
+import { afterAll, describe, expect, test, vi } from "vitest"
 
 import { initCommand } from "@/commands/init"
-import { checkJsonInit } from "@/common/get-config"
+import {
+  checkJsonInit,
+  getBaseAlias,
+  getStyleAlias,
+  loadTSConfig,
+} from "@/common/get-config"
 import { checkPandaInit } from "@/common/get-config"
-
-const TS_CONFIG = {
-  compilerOptions: {
-    paths: {
-      "@/*": ["./src/"],
-      "@styled-system/*": ["./styled-system/"],
-      "@utils/*": ["./src/utils/"],
-    },
-  },
-}
-
-const PACKAGE_JSON = {
-  devDependencies: {
-    "@pandacss/dev": "^1.0.0",
-  },
-}
-
-// const COMPONENTS_JSON = {
-//   utils: "@/utils",
-//   components: "@/components",
-//   hooks: "@/hooks",
-//   styledsystem: "@styled-system",
-// }
-
-const PANDA_CONFIG_TS = `import { defineConfig } from "@pandacss/dev"
-
-export default defineConfig({
-  // Whether to use css reset
-  preflight: true,
-
-  // Where to look for your css declarations
-  include: ["./src//*.{js,jsx,ts,tsx}", "./pages//*.{js,jsx,ts,tsx}"],
-
-  // Files to exclude
-  exclude: [],
-
-  // Useful for theme customization
-  theme: {
-    extend: {},
-  },
-
-  // The output directory for your css system
-  outdir: "styled-system",
-})
-`
 
 const PRESET_TS = {
   name: "preset.ts",
   dependencies: [],
   file: '"import {\\n  defineGlobalStyles,\\n  definePreset,\\n  defineSemanticTokens,\\n  defineTokens,\\n} from \\"@pandacss/dev\\"\\n\\nconst globalCss = defineGlobalStyles({\\n  \\"html, body\\": {\\n    w: \\"full\\",\\n    h: \\"full\\",\\n  },\\n})\\n\\nconst radii = defineTokens.radii({\\n  radius: { value: \\"0.5rem\\" },\\n})\\n\\nexport const semanticColors = defineSemanticTokens.colors({\\n  background: {\\n    value: { base: \\"hsl(0 0% 100%)\\", _dark: \\"hsl(222.2 84% 4.9%)\\" },\\n  },\\n  foreground: {\\n    value: { base: \\"hsl(222.2 84% 4.9%)\\", _dark: \\"hsl(210 40% 98%)\\" },\\n  },\\n  card: {\\n    DEFAULT: {\\n      value: { base: \\"hsl(0 0% 100%)\\", _dark: \\"hsl(222.2 84% 4.9%)\\" },\\n    },\\n    foreground: {\\n      value: { base: \\"hsl(222.2 84% 4.9%)\\", _dark: \\"hsl(210 40% 98%)\\" },\\n    },\\n  },\\n  popover: {\\n    DEFAULT: {\\n      value: { base: \\"hsl(0 0% 100%)\\", _dark: \\"hsl(222.2 84% 4.9%)\\" },\\n    },\\n    foreground: {\\n      value: { base: \\"hsl(222.2 84% 4.9%)\\", _dark: \\"hsl(210 40% 98%)\\" },\\n    },\\n  },\\n  primary: {\\n    DEFAULT: {\\n      value: { base: \\"hsl(222.2 47.4% 11.2%)\\", _dark: \\"hsl(210 40% 98%)\\" },\\n    },\\n    foreground: {\\n      value: { base: \\"hsl(210 40% 98%)\\", _dark: \\"hsl(222.2 47.4% 11.2%)\\" },\\n    },\\n  },\\n  secondary: {\\n    DEFAULT: {\\n      value: { base: \\"hsl(210 40% 96.1%)\\", _dark: \\"hsl(217.2 32.6% 17.5%)\\" },\\n    },\\n    foreground: {\\n      value: { base: \\"hsl(222.2 47.4% 11.2%)\\", _dark: \\"hsl(210 40% 98%)\\" },\\n    },\\n  },\\n  muted: {\\n    DEFAULT: {\\n      value: { base: \\"hsl(210 40% 96.1%)\\", _dark: \\"hsl(217.2 32.6% 17.5%)\\" },\\n    },\\n    foreground: {\\n      value: {\\n        base: \\"hsl(215.4 16.3% 46.9%)\\",\\n        _dark: \\"hsl(215 20.2% 65.1%)\\",\\n      },\\n    },\\n  },\\n  accent: {\\n    DEFAULT: {\\n      value: { base: \\"hsl(210 40% 96.1%)\\", _dark: \\"hsl(217.2 32.6% 17.5%)\\" },\\n    },\\n    foreground: {\\n      value: { base: \\"hsl(222.2 47.4% 11.2%)\\", _dark: \\"hsl(210 40% 98%)\\" },\\n    },\\n  },\\n  destructive: {\\n    DEFAULT: {\\n      value: { base: \\"hsl(0 84.2% 60.2%)\\", _dark: \\"hsl(0 62.8% 30.6%)\\" },\\n    },\\n    foreground: {\\n      value: { base: \\"hsl(210 40% 98%)\\", _dark: \\"hsl(210 40% 98%)\\" },\\n    },\\n  },\\n  border: {\\n    value: {\\n      base: \\"hsl(214.3 31.8% 91.4%)\\",\\n      _dark: \\"hsl(217.2 32.6% 17.5%)\\",\\n    },\\n  },\\n  input: {\\n    value: {\\n      base: \\"hsl(214.3 31.8% 91.4%)\\",\\n      _dark: \\"hsl(217.2 32.6% 17.5%)\\",\\n    },\\n  },\\n  ring: {\\n    value: { base: \\"hsl(222.2 84% 4.9%)\\", _dark: \\"hsl(212.7 26.8% 83.9%)\\" },\\n  },\\n})\\n\\nconst borders = defineSemanticTokens.borders({\\n  base: { value: \\"1px solid {colors.border}\\" },\\n  input: { value: \\"1px solid {colors.input}\\" },\\n  primary: { value: \\"1px solid {colors.primary}\\" },\\n  destructive: { value: \\"1px solid {colors.destructive}\\" },\\n})\\n\\nexport const radius = defineSemanticTokens.radii({\\n  xl: { value: `calc({radii.radius} + 4px)` },\\n  lg: { value: `{radii.radius}` },\\n  md: { value: `calc({radii.radius} - 2px)` },\\n  sm: { value: \\"calc({radii.radius} - 4px)\\" },\\n})\\n\\nexport const defaultPreset = definePreset({\\n  name: \\"default\\",\\n  globalCss,\\n  theme: {\\n    extend: {\\n      tokens: {\\n        radii,\\n      },\\n      semanticTokens: {\\n        colors: semanticColors,\\n        radii: radius,\\n        borders: borders,\\n      },\\n    },\\n  },\\n  staticCss: {\\n    recipes: \\"*\\",\\n  },\\n})\\n"',
 }
-// init.test.ts
-describe("init 테스트", () => {
-  const temp = path.resolve(__dirname, "../temp-init")
 
-  beforeAll(async () => {
-    await fs.mkdir(temp, { recursive: true })
-    await fs.writeFile(
-      path.resolve(temp, "tsconfig.json"),
-      JSON.stringify(TS_CONFIG, null, 2),
-      "utf-8",
-    )
-    await fs.writeFile(
-      path.resolve(temp, "package.json"),
-      JSON.stringify(PACKAGE_JSON, null, 2),
-      "utf-8",
-    )
-    await fs.writeFile(
-      path.resolve(temp, "panda.config.ts"),
-      PANDA_CONFIG_TS,
-      "utf-8",
-    )
+const createdFiles = ["components.json", "preset.ts"]
+
+describe("unit 테스트", () => {
+  const cwd = path.resolve(__dirname, "./fixture/init_test")
+  const ts = loadTSConfig(cwd)
+  test("tsconfig를 분석해서 pandacss의 generated css의 alias를 찾습니다", () => {
+    expect(getStyleAlias(cwd, "/a/b/c/d", ts)).toBe("fake")
   })
 
-  afterAll(async () => {
-    await fs.remove(temp)
+  test("tsconfig를 분석해서 base alias를 찾습니다", () => {
+    expect(getBaseAlias(cwd, ts)).toBe("@")
+  })
+})
+
+describe("init 테스트", () => {
+  const cwd = path.resolve(__dirname, "./fixture/init_test")
+
+  afterAll(() => {
+    createdFiles.forEach((file) => {
+      fs.remove(path.join(cwd, file))
+    })
   })
 
   test("root 경로에 components.json 파일이 있는지 확인합니다", async () => {
-    expect(await checkJsonInit(temp)).toBeFalsy()
+    expect(await checkJsonInit(cwd)).toBeFalsy()
   })
 
   test("pandaCSS 설치 상태를 확인합니다", async () => {
-    expect(await checkPandaInit(temp)).toBeTruthy()
+    expect(await checkPandaInit(cwd)).toBeTruthy()
   })
 
   test("cli init", async () => {
@@ -99,9 +56,9 @@ describe("init 테스트", () => {
           json: () => Promise.resolve(PRESET_TS),
         }) as Promise<Response>,
     )
-    await initCommand.parseAsync(["node", "init", "-c", temp])
-    expect(fs.existsSync(path.join(temp, "preset.ts"))).toBeTruthy()
+    await initCommand.parseAsync(["node", "init", "-c", cwd])
+    createdFiles.forEach((file) => {
+      expect(fs.existsSync(path.join(cwd, file))).toBeTruthy()
+    })
   })
 })
-
-// add.test.ts

--- a/packages/cli/src/test/init.test.ts
+++ b/packages/cli/src/test/init.test.ts
@@ -5,7 +5,6 @@ import { afterAll, beforeAll, describe, expect, test, vi } from "vitest"
 import { initCommand } from "@/commands/init"
 import { checkJsonInit } from "@/common/get-config"
 import { checkPandaInit } from "@/common/get-config"
-import { getTsConfigAlias } from "@/common/get-config"
 
 const TS_CONFIG = {
   compilerOptions: {
@@ -90,13 +89,6 @@ describe("init 테스트", () => {
 
   test("pandaCSS 설치 상태를 확인합니다", async () => {
     expect(await checkPandaInit(temp)).toBeTruthy()
-  })
-
-  test("tsconfig와 panda.config.ts 설정 파일의 경로를 통해 alias를 찾습니다", async () => {
-    expect(getTsConfigAlias(temp, "styled-system")).toStrictEqual({
-      baseAlias: "@",
-      styledSystemAlias: "@styled-system",
-    })
   })
 
   test("cli init", async () => {


### PR DESCRIPTION
## ✨ 설명
init cmd 기능 개선
## 🔍 주요 변경 사항
- [ ] 변수명 및 함수 위치 일부 변경
- [ ] alias를 찾는 기능 중점 개선
- [ ] cli 패키지에 engines 속성 추가(>=18)

## ✅ 테스트 결과

## 📌 참고 사항
alias 찾는 로직 개선 72aa67d83a8762bf86e06c9f770f580194983e12 8b45bd54ff1baff8fc1cc2dea4d8653b382e791f
- 기존에는 styled-system,base alias를 찾는 로직이 하나의 함수에 같이 존재. 이를 각각 분리
- 기존에는 includes로 문자열에 포함되는지만 검사, 이제는 각 paths를 baseUrl을 고려하여 path.join(or resolve)로 full path로 만든 뒤 비교하는 방식으로 변경
- init 테스트 방식 변경
  - fixture를 이용하는 방식으로 변경 