### PR TITLE
add command에서 패키지 다운 로직 제거

### DIFF
--- a/.changeset/small-tigers-brush.md
+++ b/.changeset/small-tigers-brush.md
@@ -1,0 +1,5 @@
+---
+"@jongh/cli": minor
+---
+
+remove package installation in add command

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -55,3 +55,6 @@ jobs:
           aws_region: ${{ secrets.AWS_REGION }}
           aws_s3_bucket_name: ${{ secrets.AWS_S3_BUCKET_NAME }}
           aws_cloudfront_id: ${{ secrets.AWS_CLOUDFRONT_ID }}
+
+      - name: cache playwright
+        uses: ./.github/actions/playwright

--- a/packages/cli/src/commands/add/index.ts
+++ b/packages/cli/src/commands/add/index.ts
@@ -48,7 +48,7 @@ export const addCommand = new Command()
         loadComponentConfig(options.cwd),
       )
       //2. tsconfig.json 파일을 읽어온다
-      const tsconfig = await loadTSConfig(options.cwd)
+      const tsconfig = loadTSConfig(options.cwd)
       //3. panda.config.* 파일을 읽어온다
       const pandaConfigPath = await getPandacssConfigPath(options.cwd)
 

--- a/packages/cli/src/commands/add/index.ts
+++ b/packages/cli/src/commands/add/index.ts
@@ -4,7 +4,6 @@ import { confirm, intro, outro } from "@clack/prompts"
 import chalk from "chalk"
 import { Command } from "commander"
 import fs from "fs-extra"
-import { detect } from "package-manager-detector"
 import path from "path"
 import { z, ZodError } from "zod"
 
@@ -17,6 +16,7 @@ import {
 import { resolveImport, resolvePandaConfig } from "@/common/resolve"
 import { transformImports } from "@/common/transform"
 import { configSchema, registrySchema } from "@/common/types"
+import { getPackageManagerCommand } from "@/common/utils/packageManager"
 
 const addSchema = z.object({
   components: z.array(z.string()).optional(),
@@ -138,20 +138,7 @@ export const addCommand = new Command()
               file.content,
               componentsJson,
             )
-            // if (file.name === "recipe.ts") {
-            //   //현재 export하고있는 recipe 변수명은 componentList[index]+Recipe
-            //   //이걸 preset.ts에 넣어줘야 함 - 현재는 이 파일이 root에 있다고 가정
-            //   //이 파일의 alias는 component alias / 컴포넌트명 / recipe.ts
-            //   transformPreset(
-            //     path.join(options.cwd, "preset.ts"),
-            //     `${componentList[index]}`,
-            //     path.join(
-            //       componentsJson.components,
-            //       `${componentList[index]}`,
-            //       "recipe",
-            //     ),
-            //   )
-            // }
+
             if (file.type === "ui") {
               fs.outputFileSync(path.join(src, file.name), convertedContent)
             } else {
@@ -163,31 +150,20 @@ export const addCommand = new Command()
             }
           })
 
-          await detect({ cwd: options.cwd })
+          const packageManagerCommand = await getPackageManagerCommand(
+            options.cwd,
+            registry.dependencies || [],
+          )
 
-          // let pmName = pm ? pm.name : ""
+          const outroMsg = !packageManagerCommand
+            ? `Cannot find your package manager, install this dependencies: ${registry.dependencies?.join(" ")}`
+            : `Run this command in the terminal : ${packageManagerCommand.command} ${packageManagerCommand.args.join(" ")}`
 
-          // if (!pmName) {
-          //   const selected = await select({
-          //     message: "cannot find package manager, select",
-          //     options: [
-          //       { value: "npm", label: "npm" },
-          //       { value: "pnpm", label: "pnpm" },
-          //       { value: "yarn", label: "yarn" },
-          //     ],
-          //   })
-          //   pmName = selected as string
-          // }
-          // if (registry.dependencies?.length) {
-          //   await execa(pmName, [
-          //     pmName === "npm" ? "install" : "add",
-          //     ...registry.dependencies,
-          //   ])
-          // }
-          // const runner = await getPackageManagerRunner(options.cwd)
-          // const [name, ...cmd] = runner.split(" ")
-          // execa(name, [...cmd, "panda", "codegen"])
-          // outro(info(`${componentList[index]} completed successfully`))
+          outro(
+            info(
+              `${componentList[index]} completed successfully \n ${outroMsg}`,
+            ),
+          )
         } catch (e) {
           console.log(e)
         }

--- a/packages/cli/src/commands/add/index.ts
+++ b/packages/cli/src/commands/add/index.ts
@@ -15,7 +15,7 @@ import {
   loadTSConfig,
 } from "@/common/get-config"
 import { resolveImport, resolvePandaConfig } from "@/common/resolve"
-import { transformImports, transformPreset } from "@/common/transform"
+import { transformImports } from "@/common/transform"
 import { configSchema, registrySchema } from "@/common/types"
 
 const addSchema = z.object({
@@ -138,22 +138,20 @@ export const addCommand = new Command()
               file.content,
               componentsJson,
             )
-            //TODO: file의 타입에 따라 변경하기
-            if (file.name === "recipe.ts") {
-              //현재 export하고있는 recipe 변수명은 componentList[index]+Recipe
-              //이걸 preset.ts에 넣어줘야 함 - 현재는 이 파일이 root에 있다고 가정
-              //이 파일의 alias는 component alias / 컴포넌트명 / recipe.ts
-              transformPreset(
-                path.join(options.cwd, "preset.ts"),
-                `${componentList[index]}`,
-                path.join(
-                  componentsJson.components,
-                  `${componentList[index]}`,
-                  "recipe",
-                ),
-              )
-            }
-
+            // if (file.name === "recipe.ts") {
+            //   //현재 export하고있는 recipe 변수명은 componentList[index]+Recipe
+            //   //이걸 preset.ts에 넣어줘야 함 - 현재는 이 파일이 root에 있다고 가정
+            //   //이 파일의 alias는 component alias / 컴포넌트명 / recipe.ts
+            //   transformPreset(
+            //     path.join(options.cwd, "preset.ts"),
+            //     `${componentList[index]}`,
+            //     path.join(
+            //       componentsJson.components,
+            //       `${componentList[index]}`,
+            //       "recipe",
+            //     ),
+            //   )
+            // }
             if (file.type === "ui") {
               fs.outputFileSync(path.join(src, file.name), convertedContent)
             } else {

--- a/packages/cli/src/commands/add/index.ts
+++ b/packages/cli/src/commands/add/index.ts
@@ -1,9 +1,8 @@
 #!/usr/bin/env node
 
-import { confirm, intro, outro, select } from "@clack/prompts"
+import { confirm, intro, outro } from "@clack/prompts"
 import chalk from "chalk"
 import { Command } from "commander"
-import { execa } from "execa"
 import fs from "fs-extra"
 import { detect } from "package-manager-detector"
 import path from "path"
@@ -18,7 +17,6 @@ import {
 import { resolveImport, resolvePandaConfig } from "@/common/resolve"
 import { transformImports, transformPreset } from "@/common/transform"
 import { configSchema, registrySchema } from "@/common/types"
-import { getPackageManagerRunner } from "@/common/utils/packageManager"
 
 const addSchema = z.object({
   components: z.array(z.string()).optional(),
@@ -167,31 +165,31 @@ export const addCommand = new Command()
             }
           })
 
-          const pm = await detect({ cwd: options.cwd })
+          await detect({ cwd: options.cwd })
 
-          let pmName = pm ? pm.name : ""
+          // let pmName = pm ? pm.name : ""
 
-          if (!pmName) {
-            const selected = await select({
-              message: "cannot find package manager, select",
-              options: [
-                { value: "npm", label: "npm" },
-                { value: "pnpm", label: "pnpm" },
-                { value: "yarn", label: "yarn" },
-              ],
-            })
-            pmName = selected as string
-          }
-          if (registry.dependencies?.length) {
-            await execa(pmName, [
-              pmName === "npm" ? "install" : "add",
-              ...registry.dependencies,
-            ])
-          }
-          const runner = await getPackageManagerRunner(options.cwd)
-          const [name, ...cmd] = runner.split(" ")
-          execa(name, [...cmd, "panda", "codegen"])
-          outro(info(`${componentList[index]} completed successfully`))
+          // if (!pmName) {
+          //   const selected = await select({
+          //     message: "cannot find package manager, select",
+          //     options: [
+          //       { value: "npm", label: "npm" },
+          //       { value: "pnpm", label: "pnpm" },
+          //       { value: "yarn", label: "yarn" },
+          //     ],
+          //   })
+          //   pmName = selected as string
+          // }
+          // if (registry.dependencies?.length) {
+          //   await execa(pmName, [
+          //     pmName === "npm" ? "install" : "add",
+          //     ...registry.dependencies,
+          //   ])
+          // }
+          // const runner = await getPackageManagerRunner(options.cwd)
+          // const [name, ...cmd] = runner.split(" ")
+          // execa(name, [...cmd, "panda", "codegen"])
+          // outro(info(`${componentList[index]} completed successfully`))
         } catch (e) {
           console.log(e)
         }

--- a/packages/cli/src/common/utils/packageManager.ts
+++ b/packages/cli/src/common/utils/packageManager.ts
@@ -1,19 +1,16 @@
-import { detect } from "package-manager-detector"
-
-export async function getPackageManagerRunner(cwd: string) {
+import { detect, resolveCommand } from "package-manager-detector"
+/**
+ * 사용하는 패키지 매니저를 감지하고, install 관련 올바른 command를 return
+ *
+ * ex) npm -> npm install, pnpm -> pnpm add
+ *
+ * www.npmjs.com/package/package-manager-detector
+ */
+export async function getPackageManagerCommand(cwd: string, args: string[]) {
   const pm = await detect({ cwd })
-  if (!pm) {
-    throw new Error("package manager not found")
+  const command = resolveCommand(pm?.agent || "npm", "add", args)
+  if (!command) {
+    return undefined
   }
-  if (pm.name === "pnpm") {
-    return "pnpm exec"
-  }
-  if (pm.name === "bun") {
-    return "bunx"
-  }
-  if (pm.name === "yarn") {
-    return "yarn dlx"
-  } else {
-    return "npx"
-  }
+  return command
 }


### PR DESCRIPTION
## ✨ 설명
- 기존의 add command에서 execa를 사용하여 패키지 다운 명령을 실행하던 걸 제거
## 🔍 주요 변경 사항
- [ ] 패키지 다운 로직 제거 -> 필요한 패키지를 메시지로 알려줌
- [ ] package-manager-detector 를 사용하여 정확한 패키지 install command를 찾음 fce8190367d99d763383eb158e4ab3d9d6d34064

## ✅ 테스트 결과

## 📌 참고 사항
