### PR TITLE
프리셋 파일 생성방식 변경과 테스트코드 리팩토링

### DIFF
--- a/.changeset/quiet-donkeys-bake.md
+++ b/.changeset/quiet-donkeys-bake.md
@@ -1,0 +1,5 @@
+---
+"@jongh/cli": minor
+---
+
+reorganize preset color system

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -40,6 +40,7 @@
     "execa": "^9.5.2",
     "fast-glob": "^3.3.2",
     "fs-extra": "^11.2.0",
+    "handlebars": "^4.7.8",
     "package-manager-detector": "^0.2.8",
     "pkg-dir": "^8.0.0",
     "ts-morph": "^25.0.0",
@@ -48,14 +49,14 @@
     "zod": "^3.24.1"
   },
   "devDependencies": {
+    "@jongh/eslint": "workspace:*",
+    "@jongh/tsconfig": "workspace:*",
     "@types/babel__generator": "^7.6.8",
     "@types/fs-extra": "^11.0.4",
     "@types/node": "^22.8.6",
     "@types/yargs": "^17.0.33",
     "ts-node": "^10.9.2",
     "tsup": "^8.3.0",
-    "tsx": "^4.19.2",
-    "@jongh/tsconfig": "workspace:*",
-    "@jongh/eslint": "workspace:*"
+    "tsx": "^4.19.2"
   }
 }

--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -1,4 +1,4 @@
-import { confirm, spinner } from "@clack/prompts"
+import { confirm, select, spinner } from "@clack/prompts"
 import { Command } from "commander"
 import fs from "fs-extra"
 import path from "path"
@@ -14,9 +14,14 @@ import {
 } from "@/common/get-config"
 import { getPandacssConfigPath } from "@/common/get-config"
 import { resolvePandaConfig } from "@/common/resolve"
+import {
+  colorPalette,
+  colorSchema,
+  grayColorPalette,
+  transformTemplate,
+} from "@/common/theme"
 import { transformPandaConfig } from "@/common/transform"
 import { configSchema } from "@/common/types"
-import { fetchPreset } from "@/common/utils/fetchRegistry"
 
 const initSchema = z.object({
   cwd: z.string(),
@@ -103,9 +108,44 @@ export async function init(options: z.infer<typeof initSchema>) {
     styledsystem: defaultStyledSystemAlias,
   })
 
-  const preset = await fetchPreset()
+  const primary = await select({
+    message: "Pick primary color",
+    initialValue: "neutral",
+    options: colorPalette.map((color) => ({
+      value: color,
+      label: color,
+    })),
+  })
 
-  fs.writeFile(path.join(root, preset.name), JSON.parse(preset.file))
+  const secondary = await select({
+    message: "Pick secondary color",
+    initialValue: "slate",
+    options: colorPalette.map((color) => ({
+      value: color,
+      label: color,
+    })),
+  })
+
+  const gray = await select({
+    message: "Pick gray color",
+    initialValue: "graye",
+    options: grayColorPalette.map((color) => ({
+      value: color,
+      label: color,
+    })),
+  })
+
+  const preset = transformTemplate(
+    colorSchema.parse({
+      primary,
+      secondary,
+      gray,
+    }),
+  )
+
+  // const preset = await fetchPreset()
+
+  fs.writeFile(path.join(root, "preset.ts"), preset)
 
   transformPandaConfig(path.resolve(root, pandacssConfigPath))
 

--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -48,6 +48,9 @@ export const initCommand = new Command()
       if (e instanceof CommandError) {
         console.error(e.format)
       }
+      if (e instanceof Error) {
+        console.log(e.message, e.cause)
+      }
       s.stop("Failed to initialize")
       process.exit(0)
     }
@@ -86,8 +89,6 @@ export async function init(options: z.infer<typeof initSchema>) {
   let defaultStyledSystemAlias = "styled-system"
 
   const { outdir, importMap } = await resolvePandaConfig(pandacssConfigFile)
-  // outdir은 생성된 파일들이 저장될 디렉토리를 지정하는 옵션이고,
-  // importMap은 그 디렉토리를 애플리케이션 코드에서 어떻게 import할지 경로를 매핑하는 역할
 
   //만약 importMap이 있으면 그 값을 그대로 사용
   if (importMap) {

--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -112,6 +112,12 @@ export async function init(options: z.infer<typeof initSchema>) {
     styledsystem: defaultStyledSystemAlias,
   })
 
+  fs.writeFile(
+    path.resolve(root, "components.json"),
+    JSON.stringify(config),
+    "utf-8",
+  )
+
   let primary = "neutral"
   let secondary = "slate"
   let gray = "gray"
@@ -156,12 +162,6 @@ export async function init(options: z.infer<typeof initSchema>) {
   fs.writeFile(path.join(root, "preset.ts"), preset)
 
   transformPandaConfig(path.resolve(root, pandacssConfigPath))
-
-  await fs.writeFile(
-    path.resolve(root, "components.json"),
-    JSON.stringify(config),
-    "utf-8",
-  )
 
   return config
 }

--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -25,6 +25,7 @@ import { configSchema } from "@/common/types"
 
 const initSchema = z.object({
   cwd: z.string(),
+  default: z.boolean(),
 })
 
 export const initCommand = new Command()
@@ -35,12 +36,14 @@ export const initCommand = new Command()
     "current working directory, default to process.cwd()",
     process.cwd(),
   )
+  .option("-d, --default", "use default color", false)
   .action(async (opts) => {
     const s = spinner()
     s.start("Initializing")
     try {
       const options = initSchema.parse({
         cwd: path.resolve(opts.cwd),
+        default: opts.default,
       })
       await init(options)
       s.stop("successfully Initialized!")
@@ -109,32 +112,38 @@ export async function init(options: z.infer<typeof initSchema>) {
     styledsystem: defaultStyledSystemAlias,
   })
 
-  const primary = await select({
-    message: "Pick primary color",
-    initialValue: "neutral",
-    options: colorPalette.map((color) => ({
-      value: color,
-      label: color,
-    })),
-  })
+  let primary = "neutral"
+  let secondary = "slate"
+  let gray = "gray"
 
-  const secondary = await select({
-    message: "Pick secondary color",
-    initialValue: "slate",
-    options: colorPalette.map((color) => ({
-      value: color,
-      label: color,
-    })),
-  })
+  if (!options.default) {
+    primary = (await select({
+      message: "Pick primary color",
+      initialValue: "neutral",
+      options: colorPalette.map((color) => ({
+        value: color,
+        label: color,
+      })),
+    })) as string
 
-  const gray = await select({
-    message: "Pick gray color",
-    initialValue: "graye",
-    options: grayColorPalette.map((color) => ({
-      value: color,
-      label: color,
-    })),
-  })
+    secondary = (await select({
+      message: "Pick secondary color",
+      initialValue: "slate",
+      options: colorPalette.map((color) => ({
+        value: color,
+        label: color,
+      })),
+    })) as string
+
+    gray = (await select({
+      message: "Pick gray color",
+      initialValue: "gray",
+      options: grayColorPalette.map((color) => ({
+        value: color,
+        label: color,
+      })),
+    })) as string
+  }
 
   const preset = transformTemplate(
     colorSchema.parse({
@@ -143,8 +152,6 @@ export async function init(options: z.infer<typeof initSchema>) {
       gray,
     }),
   )
-
-  // const preset = await fetchPreset()
 
   fs.writeFile(path.join(root, "preset.ts"), preset)
 

--- a/packages/cli/src/common/get-config/index.ts
+++ b/packages/cli/src/common/get-config/index.ts
@@ -18,8 +18,11 @@ export function loadComponentConfig(cwd: string) {
   }
 }
 
-// tsConfig 읽기 전용
-// loadConfig는 현재 디렉토리에 tsconfig가 없으면 경로를 내려가서 tsconfig를 찾는걸로 보임
+/**
+ *
+ * 주어진 경로를 기반으로 tsconfig.json파일을 탐색
+ * 현재 경로에 없다면, 부모 디렉토리로 이동
+ */
 export function loadTSConfig(cwd: string) {
   const tsconfig = loadConfig(cwd)
   if (tsconfig.resultType === "failed") {
@@ -53,6 +56,20 @@ export async function checkPandaInit(cwd: string) {
   return isInstalled && !!pandaConfig
 }
 
+/**
+ * react, nextJS 사용자가 일반적으로 많이 사용하는 경로를 기반으로 alias를 반환하는 함수
+ *
+ * @example
+const exampleTsConfig = {
+  baseUrl: ".",
+  paths: {
+    "@/*": ["./src/*"],
+    "@app/*": ["./src/app/*"],
+    "@components/*": ["./src/components/*"],
+  }
+}
+  getBaseAlias(process.cwd(),exampleTsConfig) // @
+ */
 export function getBaseAlias(cwd: string, tsConfig: ConfigLoaderSuccessResult) {
   const basePaths = ["./", "./src/", "./app/", "./src/app"].map((p) =>
     path.resolve(cwd, p),
@@ -74,8 +91,22 @@ export function getBaseAlias(cwd: string, tsConfig: ConfigLoaderSuccessResult) {
 
   return null
 }
-//outdir을 설정하면
-//outdir의 경로는 process.cwd+outdir
+
+/**
+ * pandacss의 output 경로에 해당하는 alias를 반환하는 함수
+ * @param styleFolderName panda.config의 output 설정, 기본값은 styled-system
+ * @example
+const exampleTsConfig = {
+  baseUrl: ".",
+  paths: {
+    "@/*": ["./src/*"],
+    "@app/*": ["./src/app/*"],
+    "@styledSysytem/*": ["./styled-system/*"],
+  }
+}
+  getBaseAlias(process.cwd(),exampleTsConfig) // '@styledSysytem'
+ */
+
 export function getStyleAlias(
   cwd: string,
   styleFolderName: string,

--- a/packages/cli/src/common/resolve/index.ts
+++ b/packages/cli/src/common/resolve/index.ts
@@ -35,6 +35,14 @@ export async function resolveAllPaths(
   }
 }
 
+/**
+ *
+ *
+ * @returns
+ * outdir : 생성된 파일들이 저장될 디렉토리 경로
+ *
+ * importMap : 그 디렉토리를 애플리케이션 코드에서 어떻게 import할지 경로를 매핑하는 역할
+ */
 export async function resolvePandaConfig(config: string) {
   const outdirMatch = config.match(/outdir:\s*["']([^"']+)["']/)
   const importMapMatch = config.match(/importMap:\s*({[^}]+}|["'][^"']+["'])/)

--- a/packages/cli/src/common/theme/index.ts
+++ b/packages/cli/src/common/theme/index.ts
@@ -1,4 +1,7 @@
+import Handlebars from "handlebars"
 import { z } from "zod"
+
+import { template } from "./template"
 
 const colorPalette = [
   "rose",
@@ -32,3 +35,8 @@ export const colorSchema = z.object({
   secondary: z.enum(colorPalette),
   gray: z.enum(grayColorPalette),
 })
+
+export const transformTemplate = (options: z.infer<typeof colorSchema>) => {
+  const compliedTemplate = Handlebars.compile(template)
+  return compliedTemplate(options)
+}

--- a/packages/cli/src/common/theme/index.ts
+++ b/packages/cli/src/common/theme/index.ts
@@ -3,7 +3,7 @@ import { z } from "zod"
 
 import { template } from "./template"
 
-const colorPalette = [
+export const colorPalette = [
   "rose",
   "pink",
   "fuchsia",
@@ -28,7 +28,13 @@ const colorPalette = [
   "slate",
 ] as const
 
-const grayColorPalette = ["neutral", "stone", "zinc", "gray", "slate"] as const
+export const grayColorPalette = [
+  "neutral",
+  "stone",
+  "zinc",
+  "gray",
+  "slate",
+] as const
 
 export const colorSchema = z.object({
   primary: z.enum(colorPalette),

--- a/packages/cli/src/common/theme/index.ts
+++ b/packages/cli/src/common/theme/index.ts
@@ -1,0 +1,34 @@
+import { z } from "zod"
+
+const colorPalette = [
+  "rose",
+  "pink",
+  "fuchsia",
+  "purple",
+  "violet",
+  "indigo",
+  "blue",
+  "sky",
+  "cyan",
+  "teal",
+  "emerald",
+  "green",
+  "lime",
+  "yellow",
+  "amber",
+  "orange",
+  "red",
+  "neutral",
+  "stone",
+  "zinc",
+  "gray",
+  "slate",
+] as const
+
+const grayColorPalette = ["neutral", "stone", "zinc", "gray", "slate"] as const
+
+export const colorSchema = z.object({
+  primary: z.enum(colorPalette),
+  secondary: z.enum(colorPalette),
+  gray: z.enum(grayColorPalette),
+})

--- a/packages/cli/src/common/theme/template.ts
+++ b/packages/cli/src/common/theme/template.ts
@@ -1,0 +1,104 @@
+export const template = `
+  import { defineConfig, defineSemanticTokens, definePreset } from "@pandacss/dev"
+
+const colors = defineSemanticTokens.colors({
+      "background": {
+  "value": { "base": "{colors.white}", "_dark": "{colors.{{gray}}.950}" }
+},
+"foreground": {
+  "value": { "base": "{colors.{{gray}}.950}", "_dark": "{colors.{{gray}}.50}" }
+},
+"card": {
+  "DEFAULT": {
+    "value": { "base": "{colors.white}", "_dark": "{colors.{{gray}}.900}" }
+  },
+  "foreground": {
+    "value": { "base": "{colors.{{gray}}.950}", "_dark": "{colors.{{gray}}.50}" }
+  }
+},
+"popover": {
+  "DEFAULT": {
+    "value": { "base": "{colors.white}", "_dark": "{colors.{{gray}}.900}" }
+  },
+  "foreground": {
+    "value": { "base": "{colors.{{gray}}.950}", "_dark": "{colors.{{gray}}.50}" }
+  }
+},
+"primary": {
+  "DEFAULT": {
+    "value": { "base": "{colors.{{primary}}.600}", "_dark": "{colors.{{primary}}.400}" }
+  },
+  "foreground": {
+    "value": { "base": "{colors.white}", "_dark": "{colors.{{gray}}.950}" }
+  }
+},
+"secondary": {
+  "DEFAULT": {
+    "value": { "base": "{colors.{{secondary}}.600}", "_dark": "{colors.{{secondary}}.400}" }
+  },
+  "foreground": {
+    "value": { "base": "{colors.white}", "_dark": "{colors.{{gray}}.950}" }
+  }
+},
+"muted": {
+  "DEFAULT": {
+    "value": { "base": "{colors.{{gray}}.100}", "_dark": "{colors.{{gray}}.800}" }
+  },
+  "foreground": {
+    "value": { "base": "{colors.{{gray}}.500}", "_dark": "{colors.{{gray}}.400}" }
+  }
+},
+"accent": {
+  "DEFAULT": {
+    "value": { "base": "{colors.{{secondary}}.100}", "_dark": "{colors.{{secondary}}.800}" }
+  },
+  "foreground": {
+    "value": { "base": "{colors.{{secondary}}.900}", "_dark": "{colors.{{secondary}}.50}" }
+  }
+},
+"destructive": {
+  "DEFAULT": {
+    "value": { "base": "{colors.red.500}", "_dark": "{colors.red.400}" }
+  },
+  "foreground": {
+    "value": { "base": "{colors.white}", "_dark": "{colors.{{gray}}.950}" }
+  }
+},
+"border": {
+  "value": { "base": "{colors.{{gray}}.200}", "_dark": "{colors.{{gray}}.800}" }
+},
+"input": {
+  "value": { "base": "{colors.{{gray}}.200}", "_dark": "{colors.{{gray}}.800}" }
+},
+"ring": {
+  "value": { "base": "{colors.{{primary}}.500}", "_dark": "{colors.{{primary}}.400}" }
+}})
+  
+const borders = defineSemanticTokens.borders({
+  base: { value: "1px solid {colors.border}" },
+  input: { value: "1px solid {colors.input}" },
+  primary: { value: "1px solid {colors.primary}" },
+  destructive: { value: "1px solid {colors.destructive}" },
+})
+
+export const defaultPreset = definePreset({
+  name: "default",
+  globalCss: {
+    html: {
+      background: 'background',
+      color: 'foreground'
+    },
+  },
+  theme: {
+    extend: {
+      semanticTokens: {
+        colors,
+        borders,
+
+      },
+    },
+  },
+})
+
+
+`

--- a/packages/cli/src/common/theme/template.ts
+++ b/packages/cli/src/common/theme/template.ts
@@ -1,5 +1,5 @@
 export const template = `
-  import { defineConfig, defineSemanticTokens, definePreset } from "@pandacss/dev"
+  import { defineSemanticTokens, definePreset } from "@pandacss/dev"
 
 const colors = defineSemanticTokens.colors({
       "background": {

--- a/packages/cli/src/common/transform/index.ts
+++ b/packages/cli/src/common/transform/index.ts
@@ -139,7 +139,7 @@ export function transformPandaConfig(path: string) {
       // presets 속성이 없다면 추가
       configObject.addPropertyAssignment({
         name: "presets",
-        initializer: `[preset(), "@pandacss/preset-panda", defaultPreset"]`,
+        initializer: `[preset(), "@pandacss/preset-panda", defaultPreset]`,
       })
     }
 

--- a/packages/cli/src/test/add.test.ts
+++ b/packages/cli/src/test/add.test.ts
@@ -3,6 +3,9 @@ import path from "path"
 import { afterAll, beforeAll, describe, expect, test, vi } from "vitest"
 
 import { addCommand } from "@/commands/add"
+import { loadComponentConfig, loadTSConfig } from "@/common/get-config"
+import { resolveImport } from "@/common/resolve"
+import { configSchema } from "@/common/types"
 
 const BUTTON_JSON = {
   name: "button",
@@ -23,23 +26,6 @@ const BUTTON_JSON = {
   ],
 }
 
-const PACKAGE_JSON = {
-  devDependencies: {
-    "@pandacss/dev": "0.0.5",
-  },
-}
-
-const TS_CONFIG = {
-  compilerOptions: {
-    baseUrl: "src",
-    paths: {
-      "@/*": ["./*"],
-      "@styled-system/*": ["../styled-system/*"],
-      // "@utils/*": ["./src/utils/"],
-    },
-  },
-}
-
 const COMPONENTS_JSON = {
   utils: "@/utils",
   components: "@/components",
@@ -47,85 +33,58 @@ const COMPONENTS_JSON = {
   styledsystem: "@styled-system",
 }
 
-const PRESET_TS = `
-export const defaultPreset = definePreset({
-  name: "default",
-  theme: {
-    extend: {
-
-      recipes: {
-
-      },
+const TSCONFIG_JSON = {
+  compilerOptions: {
+    baseUrl: ".",
+    paths: {
+      "@/*": ["./src/*"],
+      "@styled-system/*": ["./styled-system/*"],
     },
   },
-  staticCss: {
-    recipes: "*",
-  },
-})
-`
+}
 
-const PANDA_CONFIG_TS = `export default defineConfig({
-  // Whether to use css reset
-  preflight: true,
-
-  // Where to look for your css declarations
-  include: ["./src//*.{js,jsx,ts,tsx}", "./pages//*.{js,jsx,ts,tsx}"],
-
-  // Files to exclude
-  exclude: [],
-
-  // Useful for theme customization
-  theme: {
-    extend: {},
-  },
-
-  // The output directory for your css system
-  outdir: "styled-system",
-})
-`
+const cwd = path.join(__dirname, "./fixture/add_test")
 
 describe("add test", () => {
-  const temp = path.join(__dirname, "../../../temp-add")
-
-  beforeAll(async () => {
-    await fs.mkdir(temp, { recursive: true })
-    await Promise.all([
-      fs.writeFile(
-        path.resolve(temp, "tsconfig.json"),
-        JSON.stringify(TS_CONFIG, null, 2),
-        "utf-8",
-      ),
-      fs.writeFile(
-        path.resolve(temp, "package.json"),
-        JSON.stringify(PACKAGE_JSON, null, 2),
-        "utf-8",
-      ),
-      fs.writeFile(
-        path.resolve(temp, "panda.config.ts"),
-        PANDA_CONFIG_TS,
-        "utf-8",
-      ),
-      fs.writeFile(
-        path.resolve(temp, "components.json"),
-        JSON.stringify(COMPONENTS_JSON, null, 2),
-        "utf-8",
-      ),
-      fs.writeFile(path.resolve(temp, "preset.ts"), PRESET_TS, "utf-8"),
-      //folder
-      fs.mkdir(path.join(temp, "src", "components"), {
-        recursive: true,
-      }),
-      fs.mkdir(path.join(temp, "src", "utils"), { recursive: true }),
-      fs.mkdir(path.join(temp, "src", "hooks"), { recursive: true }),
-      fs.mkdir(path.join(temp, "styled-system"), { recursive: true }),
-    ])
+  beforeAll(() => {
+    fs.writeFileSync(
+      path.join(cwd, "components.json"),
+      JSON.stringify(COMPONENTS_JSON),
+      "utf-8",
+    )
+    fs.writeFileSync(
+      path.join(cwd, "tsconfig.json"),
+      JSON.stringify(TSCONFIG_JSON),
+      "utf-8",
+    )
   })
 
-  afterAll(async () => {
-    await fs.remove(temp)
+  afterAll(() => {
+    fs.remove(path.join(cwd, "components.json"))
+    fs.remove(path.join(cwd, "tsconfig.json"))
   })
 
-  test("터미널에 add button을 입력했을 경우 ./src/components 경로에 폴더가 생성된다", async () => {
+  describe("add 유틸함수 test", () => {
+    test("현재 경로에서 components.json파일을 읽습니다", () => {
+      expect(configSchema.schema.parse(loadComponentConfig(cwd))).toEqual(
+        COMPONENTS_JSON,
+      )
+    })
+
+    test("tsconfig.json를 사용해 components.json의 alias를 실제 path로 변환합니다", async () => {
+      const tsconfig = loadTSConfig(cwd)
+
+      const componentsPath = await resolveImport(
+        COMPONENTS_JSON["components"],
+        tsconfig,
+      )
+      expect(componentsPath).equal(path.join(cwd, "src", "components"))
+    })
+  })
+
+  describe("터미널에 @jongh/cli add button을 입력합니다", () => {
+    const buttonFolder = path.join(cwd, "src", "components", "button")
+
     global.fetch = vi.fn(
       () =>
         Promise.resolve({
@@ -133,17 +92,25 @@ describe("add test", () => {
           json: () => Promise.resolve(BUTTON_JSON),
         }) as Promise<Response>,
     )
-    await addCommand.parseAsync(["node", "add", "button", "-c", temp])
 
-    expect(
-      fs.pathExistsSync(
-        path.join(temp, "src", "components", "button", "index.tsx"),
-      ),
-    ).toBeTruthy()
-    expect(
-      fs.pathExistsSync(
-        path.join(temp, "src", "components", "button", "recipe.ts"),
-      ),
-    ).toBeTruthy()
+    beforeAll(async () => {
+      await addCommand.parseAsync(["node", "add", "button", "-c", cwd])
+    })
+
+    afterAll(() => {
+      fs.remove(path.join(cwd, "src"))
+    })
+
+    test("components/button 폴더에 index.tsx파일이 생성됩니다", () => {
+      expect(
+        fs.pathExistsSync(path.join(buttonFolder, "index.tsx")),
+      ).toBeTruthy()
+    })
+
+    test("components/button 폴더에 recipe.ts 파일이 생성됩니다", () => {
+      expect(
+        fs.pathExistsSync(path.join(buttonFolder, "recipe.ts")),
+      ).toBeTruthy()
+    })
   })
 })

--- a/packages/cli/src/test/fixture/add_test/package.json
+++ b/packages/cli/src/test/fixture/add_test/package.json
@@ -1,4 +1,5 @@
 {
+  "packageManager": "pnpm@8.5.0",
   "devDependencies": {
     "@pandacss/dev": "^1.0.0"
   }

--- a/packages/cli/src/test/fixture/add_test/package.json
+++ b/packages/cli/src/test/fixture/add_test/package.json
@@ -1,0 +1,5 @@
+{
+  "devDependencies": {
+    "@pandacss/dev": "^1.0.0"
+  }
+}

--- a/packages/cli/src/test/fixture/add_test/panda.config.ts
+++ b/packages/cli/src/test/fixture/add_test/panda.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "@pandacss/dev"
+
+export default defineConfig({
+  preflight: true,
+  include: ["./src/**/*.{ts,tsx,js,jsx}", "./pages/**/*.{ts,tsx,js,jsx}"],
+  outdir: "styled-system",
+})

--- a/packages/cli/src/test/init.test.ts
+++ b/packages/cli/src/test/init.test.ts
@@ -1,6 +1,6 @@
 import fs from "fs-extra"
 import path from "path"
-import { afterAll, describe, expect, test, vi } from "vitest"
+import { afterAll, describe, expect, test } from "vitest"
 
 import { initCommand } from "@/commands/init"
 import {
@@ -11,52 +11,58 @@ import {
 } from "@/common/get-config"
 import { checkPandaInit } from "@/common/get-config"
 
-const PRESET_TS = {
-  name: "preset.ts",
-  dependencies: [],
-  file: '"import {\\n  defineGlobalStyles,\\n  definePreset,\\n  defineSemanticTokens,\\n  defineTokens,\\n} from \\"@pandacss/dev\\"\\n\\nconst globalCss = defineGlobalStyles({\\n  \\"html, body\\": {\\n    w: \\"full\\",\\n    h: \\"full\\",\\n  },\\n})\\n\\nconst radii = defineTokens.radii({\\n  radius: { value: \\"0.5rem\\" },\\n})\\n\\nexport const semanticColors = defineSemanticTokens.colors({\\n  background: {\\n    value: { base: \\"hsl(0 0% 100%)\\", _dark: \\"hsl(222.2 84% 4.9%)\\" },\\n  },\\n  foreground: {\\n    value: { base: \\"hsl(222.2 84% 4.9%)\\", _dark: \\"hsl(210 40% 98%)\\" },\\n  },\\n  card: {\\n    DEFAULT: {\\n      value: { base: \\"hsl(0 0% 100%)\\", _dark: \\"hsl(222.2 84% 4.9%)\\" },\\n    },\\n    foreground: {\\n      value: { base: \\"hsl(222.2 84% 4.9%)\\", _dark: \\"hsl(210 40% 98%)\\" },\\n    },\\n  },\\n  popover: {\\n    DEFAULT: {\\n      value: { base: \\"hsl(0 0% 100%)\\", _dark: \\"hsl(222.2 84% 4.9%)\\" },\\n    },\\n    foreground: {\\n      value: { base: \\"hsl(222.2 84% 4.9%)\\", _dark: \\"hsl(210 40% 98%)\\" },\\n    },\\n  },\\n  primary: {\\n    DEFAULT: {\\n      value: { base: \\"hsl(222.2 47.4% 11.2%)\\", _dark: \\"hsl(210 40% 98%)\\" },\\n    },\\n    foreground: {\\n      value: { base: \\"hsl(210 40% 98%)\\", _dark: \\"hsl(222.2 47.4% 11.2%)\\" },\\n    },\\n  },\\n  secondary: {\\n    DEFAULT: {\\n      value: { base: \\"hsl(210 40% 96.1%)\\", _dark: \\"hsl(217.2 32.6% 17.5%)\\" },\\n    },\\n    foreground: {\\n      value: { base: \\"hsl(222.2 47.4% 11.2%)\\", _dark: \\"hsl(210 40% 98%)\\" },\\n    },\\n  },\\n  muted: {\\n    DEFAULT: {\\n      value: { base: \\"hsl(210 40% 96.1%)\\", _dark: \\"hsl(217.2 32.6% 17.5%)\\" },\\n    },\\n    foreground: {\\n      value: {\\n        base: \\"hsl(215.4 16.3% 46.9%)\\",\\n        _dark: \\"hsl(215 20.2% 65.1%)\\",\\n      },\\n    },\\n  },\\n  accent: {\\n    DEFAULT: {\\n      value: { base: \\"hsl(210 40% 96.1%)\\", _dark: \\"hsl(217.2 32.6% 17.5%)\\" },\\n    },\\n    foreground: {\\n      value: { base: \\"hsl(222.2 47.4% 11.2%)\\", _dark: \\"hsl(210 40% 98%)\\" },\\n    },\\n  },\\n  destructive: {\\n    DEFAULT: {\\n      value: { base: \\"hsl(0 84.2% 60.2%)\\", _dark: \\"hsl(0 62.8% 30.6%)\\" },\\n    },\\n    foreground: {\\n      value: { base: \\"hsl(210 40% 98%)\\", _dark: \\"hsl(210 40% 98%)\\" },\\n    },\\n  },\\n  border: {\\n    value: {\\n      base: \\"hsl(214.3 31.8% 91.4%)\\",\\n      _dark: \\"hsl(217.2 32.6% 17.5%)\\",\\n    },\\n  },\\n  input: {\\n    value: {\\n      base: \\"hsl(214.3 31.8% 91.4%)\\",\\n      _dark: \\"hsl(217.2 32.6% 17.5%)\\",\\n    },\\n  },\\n  ring: {\\n    value: { base: \\"hsl(222.2 84% 4.9%)\\", _dark: \\"hsl(212.7 26.8% 83.9%)\\" },\\n  },\\n})\\n\\nconst borders = defineSemanticTokens.borders({\\n  base: { value: \\"1px solid {colors.border}\\" },\\n  input: { value: \\"1px solid {colors.input}\\" },\\n  primary: { value: \\"1px solid {colors.primary}\\" },\\n  destructive: { value: \\"1px solid {colors.destructive}\\" },\\n})\\n\\nexport const radius = defineSemanticTokens.radii({\\n  xl: { value: `calc({radii.radius} + 4px)` },\\n  lg: { value: `{radii.radius}` },\\n  md: { value: `calc({radii.radius} - 2px)` },\\n  sm: { value: \\"calc({radii.radius} - 4px)\\" },\\n})\\n\\nexport const defaultPreset = definePreset({\\n  name: \\"default\\",\\n  globalCss,\\n  theme: {\\n    extend: {\\n      tokens: {\\n        radii,\\n      },\\n      semanticTokens: {\\n        colors: semanticColors,\\n        radii: radius,\\n        borders: borders,\\n      },\\n    },\\n  },\\n  staticCss: {\\n    recipes: \\"*\\",\\n  },\\n})\\n"',
-}
+const createdFiles = ["components.json", "preset.ts", "panda.config.ts"]
 
-const createdFiles = ["components.json", "preset.ts"]
-
-describe("unit 테스트", () => {
+describe("init에 사용되는 유틸함수 테스트", () => {
+  // given
   const cwd = path.resolve(__dirname, "./fixture/init_test")
   const ts = loadTSConfig(cwd)
-  test("tsconfig를 분석해서 pandacss의 generated css의 alias를 찾습니다", () => {
-    expect(getStyleAlias(cwd, "/a/b/c/d", ts)).toBe("fake")
+
+  test("tsconfig.json의 path 설정을 기준으로 주어진 경로의 alias를 반환합니다", () => {
+    // when
+    const result = getStyleAlias(cwd, "/a/b/c/d", ts)
+    // then
+    expect(result).toBe("fake")
   })
 
-  test("tsconfig를 분석해서 base alias를 찾습니다", () => {
-    expect(getBaseAlias(cwd, ts)).toBe("@")
+  test("tsconfig.json의 path 설정을 기준으로 base alias를 반환합니다", () => {
+    // when
+    const result = getBaseAlias(cwd, ts)
+    // then
+    expect(result).toBe("@")
+  })
+
+  test("root 경로에 components.json 파일이 존재하지 않는다면 false를 반환합니다", async () => {
+    // when
+    const result = await checkJsonInit(cwd)
+    // then
+    expect(result).toBeFalsy()
+  })
+
+  test("root 경로에 panda.config.* 파일이 존재한다면 true를 반환합니다", async () => {
+    // when
+    const result = await checkPandaInit(cwd)
+    // then
+    expect(result).toBeTruthy()
   })
 })
 
-describe("init 테스트", () => {
-  const cwd = path.resolve(__dirname, "./fixture/init_test")
+describe("init 명령어 입력 테스트", () => {
+  // given
+  const cwd = path.join(__dirname, "./fixture/init_test")
+  const copy = fs.readFileSync(path.join(cwd, "panda.config.ts"))
 
   afterAll(() => {
     createdFiles.forEach((file) => {
-      fs.remove(path.join(cwd, file))
+      fs.removeSync(path.join(cwd, file)) //생성된 파일 삭제
     })
+    fs.writeFileSync(path.join(cwd, "panda.config.ts"), copy, "utf-8") //revert
   })
 
-  test("root 경로에 components.json 파일이 있는지 확인합니다", async () => {
-    expect(await checkJsonInit(cwd)).toBeFalsy()
-  })
-
-  test("pandaCSS 설치 상태를 확인합니다", async () => {
-    expect(await checkPandaInit(cwd)).toBeTruthy()
-  })
-
-  test("cli init", async () => {
-    global.fetch = vi.fn(
-      () =>
-        Promise.resolve({
-          ok: true,
-          json: () => Promise.resolve(PRESET_TS),
-        }) as Promise<Response>,
-    )
-    await initCommand.parseAsync(["node", "init", "-c", cwd])
+  test("터미널에 @jongh/cli init을 입력하면 components.json과 preset.ts파일이 생성됩니다", async () => {
+    // when
+    await initCommand.parseAsync(["node", "init", "-c", cwd, "-d"])
+    // then
     createdFiles.forEach((file) => {
       expect(fs.existsSync(path.join(cwd, file))).toBeTruthy()
     })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -229,6 +229,9 @@ importers:
       fs-extra:
         specifier: ^11.2.0
         version: 11.3.0
+      handlebars:
+        specifier: ^4.7.8
+        version: 4.7.8
       package-manager-detector:
         specifier: ^0.2.8
         version: 0.2.9


### PR DESCRIPTION
## ✨ 설명
- 제공하는 프리셋 파일의 토큰(컬러)을 정의하는 방식을 변경
- 테스트코드 리팩토링 

## 🔍 주요 변경 사항
- [ ] 프리셋 파일을 템플릿으로 만들고, 입력받은 값을 통해 토큰(컬러)를 동적으로 결정할 수 있도록 변경 
- [ ] 프리셋 파일 구조 변경
- [ ] 테스트 코드 리팩토링 b65eb2d8f7f26dc10938ce08b20218e3dce1c807 ~  61ae8cce67921c222096aab7b4c5b4075709ecb1


## 📌 참고 사항
### 프리셋 파일 토큰 구조 변경
- 기존에는 컬러가 고정됨 + 토큰의 계층 구조를 사용하지 않았음(semanticToken API를 사용하긴 했지만, 다크모드 대응을 위해서만 사용)
- 이미 생성되어 있는 기본 프리셋 컬러를 활용해서 토큰의 계층 구조를 사용 + 어떤 컬러를 사용할건지를 터미널에서 입력받아 결정할 수 있도록 하면 customize가 용이할 거라 판단
#### 구현 방법
1. 터미널에서 primary , secondary , gray color를 입력받음(입력받는 값들은 pandacss 기본 preset에 정의된 컬러에 한정 f41e75656bda0a2db426796ad9ccba2fb0154152)
2. handlebar를 활용해서 템플릿 파일에 적용(템플릿 7e4d19d6128f1ed4008471df1879a506167f2905)
3. 입력받은 컬러를 활용하여 토큰 계층 구조가 적용
#### 한계점😑
- 컬러 토큰을 정의한 방법이 좋은 방법일까? 더 세세 컬러시스템을 정의해야 할까 vs 더 단순하게
- 현재 컬러 토큰을 적용했을 때 어색하지는 않을지 테스트가 충분하진 않음 

### 테스트 코드 리팩토링

#### 신경쓴 점
1. 테스트 메시지
- 여러 테스트 관련 팁에서 공통적으로 주장하는 게, 로직의 구현 내용을 구구절절 쓰는 것이 아니라 어떤 주어진 값에서 어떤 결과를 내는지에 focus를 두고 작성하는 게 더 나은 것 같다는 생각이 듦
ex)
```js
test("pandaCSS 설치 상태를 확인합니다", async () => {
    expect(await checkPandaInit(cwd)).toBeTruthy()
  })

 설치 상태라는게 뭔지..? 지금 현재 저 함수의 경우 bool을 리턴하는 단순 함수일 뿐인데 설치 상태 라는건 현재의 나만 아는 값이 아닐까?

 test("root 경로에 panda.config.* 파일이 존재한다면 true를 반환합니다", async () => {
    // when
    const result = await checkPandaInit(cwd)
    // then
    expect(result).toBeTruthy()
  })
```
2. 코드적으로 효율적이게 변경
- 변수명 변경, describe 중첩, async/sync 고려 등
3. add test의 경우 fixture + 파일 생성을 동시에 사용하도록 변경
- tsconfig, components.json의 값을 참조해서 테스트해야 하는 경우가 많은데, 이걸 모두 fixture에 미리 생성해 놓을 경우 테스트 작성을 위해 왔다갔다 해야 하는 경우가 많아질 것 같다는 판단
- 파일 생성/삭제 로직이 추가된다는 단점도 있긴 함