### PR TITLE
calendar 컴포넌트 기본 로직 구현

### DIFF
--- a/packages/ui/src/component/calendar/ui/index.tsx
+++ b/packages/ui/src/component/calendar/ui/index.tsx
@@ -1,13 +1,3 @@
-import "dayjs/locale/ko"
-
-import dayjs from "dayjs"
-import localeData from "dayjs/plugin/localeData"
-import updateLocale from "dayjs/plugin/updateLocale"
-
-dayjs.extend(localeData)
-dayjs.extend(updateLocale)
-dayjs.locale("ko")
-
 import { Context, useControllableState } from "radix-ui/internal"
 import { type ReactNode, useCallback, useMemo } from "react"
 
@@ -22,7 +12,8 @@ type DateFormat = {
 }
 export interface CalendarContextType {
   value: DateFormat
-  weekStart?: 0 | 1
+  weekStart: 0 | 1
+
   onChange: (value: Date) => void
   onMonthChange: (amount: number) => void
   onYearChange: (amount: number) => void
@@ -53,34 +44,55 @@ export const Calendar = ({
     onChange,
   })
 
-  dayjs.updateLocale("ko", { weekStart })
-
   const onMonthChange = useCallback(
     (amount: number) => {
-      setDateValue((prevDate) => dayjs(prevDate).add(amount, "month").toDate())
+      const newDate = new Date(dateValue)
+      newDate.setMonth(newDate.getMonth() + amount)
+      setDateValue(newDate)
     },
-    [setDateValue],
+    [dateValue, setDateValue],
   )
 
   const onYearChange = useCallback(
     (amount: number) => {
-      setDateValue((prevDate) => dayjs(prevDate).add(amount, "year").toDate())
+      const newDate = new Date(dateValue)
+      newDate.setFullYear(newDate.getFullYear() + amount)
+      setDateValue(newDate)
     },
-    [setDateValue],
+    [dateValue, setDateValue],
   )
 
-  // 날짜 계산 로직을 useMemo로 최적화
   const dateFormat = useMemo(() => {
-    const currentDate = dayjs(dateValue)
+    const currentDate = new Date(dateValue)
+    const firstDay = new Date(
+      currentDate.getFullYear(),
+      currentDate.getMonth(),
+      1,
+    )
+    const lastDay = new Date(
+      currentDate.getFullYear(),
+      currentDate.getMonth() + 1,
+      0,
+    )
+    const prevMonthLastDay = new Date(
+      currentDate.getFullYear(),
+      currentDate.getMonth(),
+      0,
+    )
+    const nextMonthFirstDay = new Date(
+      currentDate.getFullYear(),
+      currentDate.getMonth() + 1,
+      1,
+    )
+
     return {
-      year: currentDate.year(),
-      month: currentDate.month() + 1,
-      day: currentDate.date(),
-      daysInMonth: currentDate.daysInMonth(),
-      startWeek: currentDate.startOf("month").day() - weekStart,
-      daysInPrevMonth: currentDate.subtract(1, "month").daysInMonth(),
-      nextMonthStartWeek:
-        currentDate.add(1, "month").startOf("month").day() - weekStart,
+      year: currentDate.getFullYear(),
+      month: currentDate.getMonth() + 1,
+      day: currentDate.getDate(),
+      daysInMonth: lastDay.getDate(),
+      startWeek: firstDay.getDay() - weekStart,
+      daysInPrevMonth: prevMonthLastDay.getDate(),
+      nextMonthStartWeek: nextMonthFirstDay.getDay() - weekStart,
     }
   }, [dateValue, weekStart])
 
@@ -151,17 +163,28 @@ export const Days = () => {
 }
 
 interface HeaderProps {
-  short?: boolean
+  format?: "short" | "long"
 }
 
-export const Header = ({ short = true }: HeaderProps) => {
-  const weekdays = short ? dayjs.weekdaysShort(true) : dayjs.weekdays(true)
+export const Header = ({ format = "short" }: HeaderProps) => {
+  const { weekStart } = useCalendarContext(contextScopeName)
 
   return (
     <div style={{ display: "flex", justifyContent: "space-between" }}>
-      {weekdays.map((day) => (
-        <div key={day}>{day}</div>
+      {getWeekdays(weekStart, "ko-KR", format).map((day, index) => (
+        <div key={index}>{day}</div>
       ))}
     </div>
   )
+}
+
+function getWeekdays(
+  weekStart: 0 | 1,
+  locale: Intl.LocalesArgument,
+  format: Intl.DateTimeFormatOptions["weekday"] = "short",
+): string[] {
+  return Array.from({ length: 7 }, (_, i) => {
+    const date = new Date(2024, 0, i + weekStart) //temp
+    return new Intl.DateTimeFormat(locale, { weekday: format }).format(date)
+  })
 }

--- a/packages/ui/src/component/calendar/ui/index.tsx
+++ b/packages/ui/src/component/calendar/ui/index.tsx
@@ -8,11 +8,12 @@ type DateFormat = {
   day: number
   daysInMonth: number
   daysInPrevMonth: number
-  startWeek: 0 | 1 | 2 | 3 | 4 | 5 | 6
-  nextMonthStartWeek: 0 | 1 | 2 | 3 | 4 | 5 | 6
+  startWeek: number //0 | 1 | 2 | 3 | 4 | 5 | 6
+  nextMonthStartWeek: number //0 | 1 | 2 | 3 | 4 | 5 | 6
 }
 export interface CalendarContextType {
   value: DateFormat
+  weekStart?: 0 | 1
   onChange: (value: Date) => void
 }
 
@@ -25,6 +26,7 @@ export type CalendarRootProps = {
   value?: Date
   defaultValue?: Date
   onChange?: (date: Date) => void
+  weekStart?: 0 | 1 // 0: 일요일, 1: 월요일
 }
 
 export const Calendar = ({
@@ -32,6 +34,7 @@ export const Calendar = ({
   value,
   defaultValue,
   onChange,
+  weekStart = 0,
 }: CalendarRootProps) => {
   const [dateValue = new Date(), setDateValue] = useControllableState({
     prop: value,
@@ -46,13 +49,18 @@ export const Calendar = ({
     month: currentDate.month() + 1,
     day: currentDate.date(),
     daysInMonth: currentDate.daysInMonth(),
-    startWeek: currentDate.startOf("month").day(), // 1일의 요일
+    startWeek: currentDate.startOf("month").day() - weekStart,
     daysInPrevMonth: currentDate.subtract(1, "month").daysInMonth(),
-    nextMonthStartWeek: currentDate.add(1, "month").startOf("month").day(),
+    nextMonthStartWeek:
+      currentDate.add(1, "month").startOf("month").day() - weekStart,
   } satisfies DateFormat
 
   return (
-    <CalendarProvider value={dateFormat} onChange={setDateValue}>
+    <CalendarProvider
+      value={dateFormat}
+      onChange={setDateValue}
+      weekStart={weekStart}
+    >
       {children}
     </CalendarProvider>
   )
@@ -61,22 +69,36 @@ export const Calendar = ({
 export const Days = () => {
   const { value } = useCalendarContext(contextScopeName)
 
-  useMemo(() => {
-    const days: number[] = [] //7*6
+  const weeks = useMemo(() => {
+    const days: Array<{ day: number; isCurrentMonth: boolean }> = []
 
     for (let i = value.startWeek; i > 0; i--) {
-      days.push(value.daysInPrevMonth - i + 1)
-    } //display previous
+      days.push({
+        day: value.daysInPrevMonth - i + 1,
+        isCurrentMonth: false,
+      })
+    }
 
     for (let i = 1; i <= value.daysInMonth; i++) {
-      days.push(i)
-    } //display current
+      days.push({
+        day: i,
+        isCurrentMonth: true,
+      })
+    }
 
     for (let i = 1; i <= 6 - value.nextMonthStartWeek + 1; i++) {
-      days.push(i)
-    } //display next
+      days.push({
+        day: i,
+        isCurrentMonth: false,
+      })
+    }
 
-    return days
+    const weeks = []
+    for (let i = 0; i < days.length; i += 7) {
+      weeks.push(days.slice(i, i + 7))
+    }
+
+    return weeks
   }, [
     value.startWeek,
     value.daysInMonth,
@@ -84,5 +106,15 @@ export const Days = () => {
     value.nextMonthStartWeek,
   ])
 
-  return <div></div>
+  return (
+    <div>
+      {weeks.map((week, weekIndex) => (
+        <div key={weekIndex} style={{ display: "flex" }}>
+          {week.map((day, dayIndex) => (
+            <div key={`${weekIndex}-${dayIndex}`}>{day.day}</div>
+          ))}
+        </div>
+      ))}
+    </div>
+  )
 }

--- a/packages/ui/src/component/calendar/ui/index.tsx
+++ b/packages/ui/src/component/calendar/ui/index.tsx
@@ -1,6 +1,6 @@
 import dayjs from "dayjs"
 import { Context, useControllableState } from "radix-ui/internal"
-import type { ReactNode } from "react"
+import { type ReactNode, useMemo } from "react"
 
 type DateFormat = {
   year: number
@@ -9,6 +9,7 @@ type DateFormat = {
   daysInMonth: number
   daysInPrevMonth: number
   startWeek: 0 | 1 | 2 | 3 | 4 | 5 | 6
+  nextMonthStartWeek: 0 | 1 | 2 | 3 | 4 | 5 | 6
 }
 export interface CalendarContextType {
   value: DateFormat
@@ -47,6 +48,7 @@ export const Calendar = ({
     daysInMonth: currentDate.daysInMonth(),
     startWeek: currentDate.startOf("month").day(), // 1일의 요일
     daysInPrevMonth: currentDate.subtract(1, "month").daysInMonth(),
+    nextMonthStartWeek: currentDate.add(1, "month").startOf("month").day(),
   } satisfies DateFormat
 
   return (
@@ -58,6 +60,29 @@ export const Calendar = ({
 
 export const Days = () => {
   const { value } = useCalendarContext(contextScopeName)
-  console.log(value)
+
+  useMemo(() => {
+    const days: number[] = [] //7*6
+
+    for (let i = value.startWeek; i > 0; i--) {
+      days.push(value.daysInPrevMonth - i + 1)
+    } //display previous
+
+    for (let i = 1; i <= value.daysInMonth; i++) {
+      days.push(i)
+    } //display current
+
+    for (let i = 1; i <= 6 - value.nextMonthStartWeek + 1; i++) {
+      days.push(i)
+    } //display next
+
+    return days
+  }, [
+    value.startWeek,
+    value.daysInMonth,
+    value.daysInPrevMonth,
+    value.nextMonthStartWeek,
+  ])
+
   return <div></div>
 }

--- a/packages/ui/src/component/calendar/ui/index.tsx
+++ b/packages/ui/src/component/calendar/ui/index.tsx
@@ -1,14 +1,23 @@
+import dayjs from "dayjs"
 import { Context, useControllableState } from "radix-ui/internal"
 import type { ReactNode } from "react"
 
+type DateFormat = {
+  year: number
+  month: number
+  day: number
+  daysInMonth: number
+  daysInPrevMonth: number
+  startWeek: 0 | 1 | 2 | 3 | 4 | 5 | 6
+}
 export interface CalendarContextType {
-  value: Date
+  value: DateFormat
   onChange: (value: Date) => void
 }
 
 const contextScopeName = "calendar"
 
-const [CalendarProvider] =
+const [CalendarProvider, useCalendarContext] =
   Context.createContext<CalendarContextType>(contextScopeName)
 export type CalendarRootProps = {
   children?: ReactNode
@@ -28,9 +37,27 @@ export const Calendar = ({
     defaultProp: defaultValue,
     onChange,
   })
+
+  const currentDate = dayjs(dateValue)
+
+  const dateFormat = {
+    year: currentDate.year(),
+    month: currentDate.month() + 1,
+    day: currentDate.date(),
+    daysInMonth: currentDate.daysInMonth(),
+    startWeek: currentDate.startOf("month").day(), // 1일의 요일
+    daysInPrevMonth: currentDate.subtract(1, "month").daysInMonth(),
+  } satisfies DateFormat
+
   return (
-    <CalendarProvider value={dateValue} onChange={setDateValue}>
+    <CalendarProvider value={dateFormat} onChange={setDateValue}>
       {children}
     </CalendarProvider>
   )
+}
+
+export const Days = () => {
+  const { value } = useCalendarContext(contextScopeName)
+  console.log(value)
+  return <div></div>
 }

--- a/packages/ui/src/component/calendar/ui/index.tsx
+++ b/packages/ui/src/component/calendar/ui/index.tsx
@@ -7,7 +7,7 @@ dayjs.extend(localeData)
 dayjs.locale("ko")
 
 import { Context, useControllableState } from "radix-ui/internal"
-import { type ReactNode, useMemo } from "react"
+import { type ReactNode, useCallback, useMemo } from "react"
 
 type DateFormat = {
   year: number
@@ -22,6 +22,8 @@ export interface CalendarContextType {
   value: DateFormat
   weekStart?: 0 | 1
   onChange: (value: Date) => void
+  onMonthChange: (amount: number) => void
+  onYearChange: (amount: number) => void
 }
 
 const contextScopeName = "calendar"
@@ -33,7 +35,7 @@ export type CalendarRootProps = {
   value?: Date
   defaultValue?: Date
   onChange?: (date: Date) => void
-  weekStart?: 0 | 1 // 0: 일요일, 1: 월요일
+  weekStart: 0 | 1 // 0: 일요일, 1: 월요일
 }
 
 export const Calendar = ({
@@ -49,23 +51,41 @@ export const Calendar = ({
     onChange,
   })
 
-  const currentDate = dayjs(dateValue)
+  const onMonthChange = useCallback(
+    (amount: number) => {
+      setDateValue((prevDate) => dayjs(prevDate).add(amount, "month").toDate())
+    },
+    [setDateValue],
+  )
 
-  const dateFormat = {
-    year: currentDate.year(),
-    month: currentDate.month() + 1,
-    day: currentDate.date(),
-    daysInMonth: currentDate.daysInMonth(),
-    startWeek: currentDate.startOf("month").day() - weekStart,
-    daysInPrevMonth: currentDate.subtract(1, "month").daysInMonth(),
-    nextMonthStartWeek:
-      currentDate.add(1, "month").startOf("month").day() - weekStart,
-  } satisfies DateFormat
+  const onYearChange = useCallback(
+    (amount: number) => {
+      setDateValue((prevDate) => dayjs(prevDate).add(amount, "year").toDate())
+    },
+    [setDateValue],
+  )
+
+  // 날짜 계산 로직을 useMemo로 최적화
+  const dateFormat = useMemo(() => {
+    const currentDate = dayjs(dateValue)
+    return {
+      year: currentDate.year(),
+      month: currentDate.month() + 1,
+      day: currentDate.date(),
+      daysInMonth: currentDate.daysInMonth(),
+      startWeek: currentDate.startOf("month").day() - weekStart,
+      daysInPrevMonth: currentDate.subtract(1, "month").daysInMonth(),
+      nextMonthStartWeek:
+        currentDate.add(1, "month").startOf("month").day() - weekStart,
+    }
+  }, [dateValue, weekStart])
 
   return (
     <CalendarProvider
       value={dateFormat}
       onChange={setDateValue}
+      onMonthChange={onMonthChange}
+      onYearChange={onYearChange}
       weekStart={weekStart}
     >
       {children}

--- a/packages/ui/src/component/calendar/ui/index.tsx
+++ b/packages/ui/src/component/calendar/ui/index.tsx
@@ -1,4 +1,11 @@
+import "dayjs/locale/ko"
+
 import dayjs from "dayjs"
+import localeData from "dayjs/plugin/localeData"
+
+dayjs.extend(localeData)
+dayjs.locale("ko")
+
 import { Context, useControllableState } from "radix-ui/internal"
 import { type ReactNode, useMemo } from "react"
 

--- a/packages/ui/src/component/calendar/ui/index.tsx
+++ b/packages/ui/src/component/calendar/ui/index.tsx
@@ -2,8 +2,10 @@ import "dayjs/locale/ko"
 
 import dayjs from "dayjs"
 import localeData from "dayjs/plugin/localeData"
+import updateLocale from "dayjs/plugin/updateLocale"
 
 dayjs.extend(localeData)
+dayjs.extend(updateLocale)
 dayjs.locale("ko")
 
 import { Context, useControllableState } from "radix-ui/internal"
@@ -50,6 +52,8 @@ export const Calendar = ({
     defaultProp: defaultValue,
     onChange,
   })
+
+  dayjs.updateLocale("ko", { weekStart })
 
   const onMonthChange = useCallback(
     (amount: number) => {

--- a/packages/ui/src/component/calendar/ui/index.tsx
+++ b/packages/ui/src/component/calendar/ui/index.tsx
@@ -1,0 +1,36 @@
+import { Context, useControllableState } from "radix-ui/internal"
+import type { ReactNode } from "react"
+
+export interface CalendarContextType {
+  value: Date
+  onChange: (value: Date) => void
+}
+
+const contextScopeName = "calendar"
+
+const [CalendarProvider] =
+  Context.createContext<CalendarContextType>(contextScopeName)
+export type CalendarRootProps = {
+  children?: ReactNode
+  value?: Date
+  defaultValue?: Date
+  onChange?: (date: Date) => void
+}
+
+export const Calendar = ({
+  children,
+  value,
+  defaultValue,
+  onChange,
+}: CalendarRootProps) => {
+  const [dateValue = new Date(), setDateValue] = useControllableState({
+    prop: value,
+    defaultProp: defaultValue,
+    onChange,
+  })
+  return (
+    <CalendarProvider value={dateValue} onChange={setDateValue}>
+      {children}
+    </CalendarProvider>
+  )
+}

--- a/packages/ui/src/component/calendar/ui/index.tsx
+++ b/packages/ui/src/component/calendar/ui/index.tsx
@@ -149,3 +149,19 @@ export const Days = () => {
     </div>
   )
 }
+
+interface HeaderProps {
+  short?: boolean
+}
+
+export const Header = ({ short = true }: HeaderProps) => {
+  const weekdays = short ? dayjs.weekdaysShort(true) : dayjs.weekdays(true)
+
+  return (
+    <div style={{ display: "flex", justifyContent: "space-between" }}>
+      {weekdays.map((day) => (
+        <div key={day}>{day}</div>
+      ))}
+    </div>
+  )
+}

--- a/packages/ui/src/component/calendar/ui/index.tsx
+++ b/packages/ui/src/component/calendar/ui/index.tsx
@@ -13,6 +13,7 @@ type DateFormat = {
 export interface CalendarContextType {
   value: DateFormat
   weekStart: 0 | 1
+  locale: Intl.LocalesArgument
 
   onChange: (value: Date) => void
   onMonthChange: (amount: number) => void
@@ -29,6 +30,7 @@ export type CalendarRootProps = {
   defaultValue?: Date
   onChange?: (date: Date) => void
   weekStart: 0 | 1 // 0: 일요일, 1: 월요일
+  locale?: Intl.LocalesArgument
 }
 
 export const Calendar = ({
@@ -37,6 +39,7 @@ export const Calendar = ({
   defaultValue,
   onChange,
   weekStart = 0,
+  locale = "en-US",
 }: CalendarRootProps) => {
   const [dateValue = new Date(), setDateValue] = useControllableState({
     prop: value,
@@ -103,6 +106,7 @@ export const Calendar = ({
       onMonthChange={onMonthChange}
       onYearChange={onYearChange}
       weekStart={weekStart}
+      locale={locale}
     >
       {children}
     </CalendarProvider>
@@ -167,11 +171,11 @@ interface HeaderProps {
 }
 
 export const Header = ({ format = "short" }: HeaderProps) => {
-  const { weekStart } = useCalendarContext(contextScopeName)
+  const { weekStart, locale } = useCalendarContext(contextScopeName)
 
   return (
     <div style={{ display: "flex", justifyContent: "space-between" }}>
-      {getWeekdays(weekStart, "ko-KR", format).map((day, index) => (
+      {getWeekdays(weekStart, locale, format).map((day, index) => (
         <div key={index}>{day}</div>
       ))}
     </div>

--- a/packages/ui/src/stories/calendar.stories.tsx
+++ b/packages/ui/src/stories/calendar.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from "@storybook/react"
+
+import { Calendar, Days, Header } from "../component/calendar/ui"
+
+const meta = {
+  title: "Calendar",
+  tags: ["autodocs"],
+  component: Calendar,
+} satisfies Meta<typeof Calendar>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Primary: Story = {
+  args: {
+    weekStart: 0,
+  },
+  render: (args) => {
+    return (
+      <Calendar {...args}>
+        <Header />
+        <Days />
+      </Calendar>
+    )
+  },
+}


### PR DESCRIPTION
## ✨ 설명
calendar 컴포넌트의 날짜 관련 기본 로직을 구현하였습니다
## 🔍 주요 변경 사항
- [ ] useControllableState를 사용하여 제어/비제어 둘다 control
- [ ] 주입된 하나의 날짜(Date 타입)에 대해서 Provider를 통해 각 하위 컴포넌트(Header,Week 이런식으로 나눌 것 같은데 나머지는 아직 구현안함)에서 내려받아서 사용
- [ ] Date 타입을 필요한 값만 뽑아서 사용 - [3443425](https://github.com/jongh-design-system/j-design-system/pull/149/commits/3443425614fbb522dcaf96277730f8dda1257d88) 의 `DateFormat` 에 해당

## ✅ 테스트 결과

## 📌 참고 사항
### dayjs 제거
- dayjs + plugin 사용이 생각보다 복잡
- locale 관련 처리 등을 Intl을 사용하면 가능할것으로 보여서 굳이 사용할 이유가 없을 것 같아 제거 [ea367f8](https://github.com/jongh-design-system/j-design-system/pull/149/commits/ea367f8cccec936de00f6a17a4d1c17d1188f6fc)