### PR TITLE
CLI error message improvement

### DIFF
--- a/packages/cli/src/commands/add/index.ts
+++ b/packages/cli/src/commands/add/index.ts
@@ -60,12 +60,21 @@ export const addCommand = new Command()
       const { outdir } = await resolvePandaConfig(config)
       //최종 경로
 
-      const paths = configSchema.schema.parse({
-        utils: await resolveImport(componentsJson.utils, tsconfig),
-        components: await resolveImport(componentsJson.components, tsconfig),
-        hooks: await resolveImport(componentsJson.hooks, tsconfig),
-        styledsystem: path.join(options.cwd, outdir || "styled-system"),
-      })
+      const paths = configSchema.schema.parse(
+        {
+          utils: await resolveImport(componentsJson.utils, tsconfig),
+          components: await resolveImport(componentsJson.components, tsconfig),
+          hooks: await resolveImport(componentsJson.hooks, tsconfig),
+          styledsystem: path.join(options.cwd, outdir || "styled-system"),
+        },
+        {
+          errorMap: () => {
+            return {
+              message: `validation failed at components.json`,
+            }
+          },
+        },
+      )
       //fetch
       const componentList = options.components?.map((c) => c.toLowerCase())
 
@@ -104,7 +113,7 @@ export const addCommand = new Command()
               })
             }
             if (e instanceof Error) {
-              throw ErrorMap(e.cause as FetchIssue) //TODO : remove assertion
+              throw ErrorMap(e.cause as FetchIssue)
             }
           }
         }),
@@ -169,17 +178,16 @@ export const addCommand = new Command()
         }
       })
     } catch (e) {
-      console.log(e)
+      outro(error(info("error occured")))
       if (e instanceof ZodError) {
-        error(e.message)
+        console.log(e.message)
       }
       if (e instanceof CommandError) {
-        error(e.format)
+        console.log(error(e.format))
       }
       if (e instanceof Error) {
-        error(e.message)
+        console.log(error(e.message))
       }
-      outro(info("error occured"))
       process.exit(1)
     }
   })

--- a/packages/cli/src/commands/add/index.ts
+++ b/packages/cli/src/commands/add/index.ts
@@ -5,9 +5,9 @@ import chalk from "chalk"
 import { Command } from "commander"
 import fs from "fs-extra"
 import path from "path"
-import { z, ZodError } from "zod"
+import { z } from "zod"
 
-import { CommandError, ErrorMap, type FetchIssue } from "@/common/error"
+import { CommandError, ErrorMap } from "@/common/error"
 import {
   getPandacssConfigPath,
   loadComponentConfig,
@@ -25,6 +25,9 @@ const addSchema = z.object({
 
 const BASE_URL = "https://whdgur.shop"
 
+const error = chalk.bold.red
+const info = chalk.bold.blue
+
 export const addCommand = new Command()
   .name("add")
   .argument("[components...]")
@@ -34,9 +37,6 @@ export const addCommand = new Command()
     process.cwd(),
   )
   .action(async (components, opts) => {
-    const error = chalk.bold.red
-    const info = chalk.bold.blue
-
     try {
       const options = addSchema.parse({
         components,
@@ -68,11 +68,9 @@ export const addCommand = new Command()
           styledsystem: path.join(options.cwd, outdir || "styled-system"),
         },
         {
-          errorMap: () => {
-            return {
-              message: `validation failed at components.json`,
-            }
-          },
+          errorMap: () => ({
+            message: `validation failed at components.json`,
+          }),
         },
       )
       //fetch
@@ -83,39 +81,17 @@ export const addCommand = new Command()
       }
 
       const results = await Promise.allSettled(
-        componentList?.map(async (c) => {
-          try {
-            const response = await fetch(`${BASE_URL}/${c}.json`)
-            if (!response.ok) {
-              const error = new Error("fetch error", {
-                cause: {
-                  code: "failed_to_fetch",
-                  target: c,
-                  statusCode: response.status,
-                  message: [response.statusText],
-                } satisfies FetchIssue,
-              })
-              throw error
-            }
-            return await response.json()
-          } catch (e) {
-            if (e instanceof TypeError) {
-              throw ErrorMap({
-                code: "failed_to_fetch",
-                target: c,
-                statusCode: null,
-                message: [
-                  error(e.message),
-                  error(
-                    e.cause ? JSON.stringify(e.cause) : "cause by typeError",
-                  ),
-                ],
-              })
-            }
-            if (e instanceof Error) {
-              throw ErrorMap(e.cause as FetchIssue)
-            }
+        componentList.map(async (c) => {
+          const response = await fetch(`${BASE_URL}/${c}.json`)
+          if (!response.ok) {
+            throw ErrorMap({
+              code: "failed_to_fetch",
+              target: c,
+              statusCode: response.status,
+              message: [response.statusText],
+            })
           }
+          return await response.json()
         }),
       )
 
@@ -123,12 +99,18 @@ export const addCommand = new Command()
         if (result.status === "rejected") {
           if (result.reason instanceof CommandError) {
             console.log(error(result.reason.format))
+          } else {
+            console.log(error(result.reason))
           }
           return
         }
         try {
           //1. registry schema check
-          const registry = registrySchema.parse(result.value)
+          const registry = registrySchema.parse(result.value, {
+            errorMap: () => ({
+              message: `registry for ${componentList[index]} is invaliad`,
+            }),
+          })
           //2.폴더를 하나 생성해야 함 -> 폴더이름은 reigstry.name
           const src = path.join(paths.components, componentList[index])
 
@@ -173,13 +155,16 @@ export const addCommand = new Command()
               `${componentList[index]} completed successfully \n ${outroMsg}`,
             ),
           )
+          process.exit(0)
         } catch (e) {
-          console.log(e)
+          if (e instanceof Error) {
+            console.log(error(e.message))
+          }
         }
       })
     } catch (e) {
       outro(error(info("error occured")))
-      if (e instanceof ZodError) {
+      if (e instanceof z.ZodError) {
         console.log(e.message)
       }
       if (e instanceof CommandError) {

--- a/packages/cli/src/commands/add/index.ts
+++ b/packages/cli/src/commands/add/index.ts
@@ -95,14 +95,14 @@ export const addCommand = new Command()
         }),
       )
 
-      results.forEach(async (result, index) => {
+      for (const [index, result] of results.entries()) {
         if (result.status === "rejected") {
           if (result.reason instanceof CommandError) {
             console.log(error(result.reason.format))
           } else {
             console.log(error(result.reason))
           }
-          return
+          continue
         }
         try {
           //1. registry schema check
@@ -155,13 +155,12 @@ export const addCommand = new Command()
               `${componentList[index]} completed successfully \n ${outroMsg}`,
             ),
           )
-          process.exit(0)
         } catch (e) {
           if (e instanceof Error) {
             console.log(error(e.message))
           }
         }
-      })
+      }
     } catch (e) {
       outro(error(info("error occured")))
       if (e instanceof z.ZodError) {
@@ -173,6 +172,6 @@ export const addCommand = new Command()
       if (e instanceof Error) {
         console.log(error(e.message))
       }
-      process.exit(1)
+      process.exit(1) // 전체 프로세스가 실패했을 때만 종료
     }
   })

--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -95,7 +95,16 @@ export async function init(options: z.infer<typeof initSchema>) {
   )
 
   const baseAlias = getBaseAlias(root, result)
-
+  if (baseAlias === null) {
+    throw ErrorMap({
+      code: "resolve_path_fail",
+      target: "tsconfig.json",
+      cwd: root,
+      message: [
+        `cannot find paths alias in your ${path.join(root, "tsconfig.json")}`,
+      ],
+    })
+  }
   let defaultStyledSystemAlias = "styled-system"
 
   const { outdir, importMap } = await resolvePandaConfig(pandacssConfigFile)

--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -1,4 +1,5 @@
 import { confirm, select, spinner } from "@clack/prompts"
+import chalk from "chalk"
 import { Command } from "commander"
 import fs from "fs-extra"
 import path from "path"
@@ -28,6 +29,8 @@ const initSchema = z.object({
   default: z.boolean(),
 })
 
+const error = chalk.bold.red
+const info = chalk.bold.blue
 export const initCommand = new Command()
   .name("init")
   .description("Initialize the project")
@@ -47,15 +50,19 @@ export const initCommand = new Command()
       })
       await init(options)
       s.stop("successfully Initialized!")
+      process.exit(0)
     } catch (e) {
+      s.stop(error(info("error occured")))
+      if (e instanceof z.ZodError) {
+        console.log(e.message)
+      }
       if (e instanceof CommandError) {
-        console.error(e.format)
+        console.log(error(e.format))
       }
       if (e instanceof Error) {
-        console.log(e.message, e.cause)
+        console.log(error(e.message))
       }
-      s.stop("Failed to initialize")
-      process.exit(0)
+      process.exit(1)
     }
   })
 
@@ -77,7 +84,7 @@ export async function init(options: z.infer<typeof initSchema>) {
       message: "you already initialize,are you want to overwrite it?",
     })
     if (!conf) {
-      process.exit(1)
+      process.exit(0)
     }
   }
 
@@ -105,12 +112,17 @@ export async function init(options: z.infer<typeof initSchema>) {
     defaultStyledSystemAlias = outdir //outdir이 있으면 경로는 outdir
   }
 
-  const config = configSchema.schema.parse({
-    utils: `${baseAlias}/utils`,
-    components: `${baseAlias}/components`,
-    hooks: `${baseAlias}/hooks`,
-    styledsystem: defaultStyledSystemAlias,
-  })
+  const config = configSchema.schema.parse(
+    {
+      utils: `${baseAlias}/utils`,
+      components: `${baseAlias}/components`,
+      hooks: `${baseAlias}/hooks`,
+      styledsystem: defaultStyledSystemAlias,
+    },
+    {
+      errorMap: () => ({ message: `components.json is invalid` }),
+    },
+  )
 
   fs.writeFile(
     path.resolve(root, "components.json"),

--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -50,7 +50,6 @@ export const initCommand = new Command()
       })
       await init(options)
       s.stop("successfully Initialized!")
-      process.exit(0)
     } catch (e) {
       s.stop(error(info("error occured")))
       if (e instanceof z.ZodError) {


### PR DESCRIPTION
This pull request includes several changes to improve error handling and code structure in the `add` and `init` commands within the `packages/cli/src/commands` directory. The key changes involve the removal of unnecessary imports, the centralization of error and info formatting, and the enhancement of error handling during schema parsing and API requests.

### Changes to `add` command:

* Removed unnecessary imports of `ZodError` and `FetchIssue` from `packages/cli/src/commands/add/index.ts`.
* Moved the `error` and `info` formatting definitions outside of the command action to avoid redundant declarations. [[1]](diffhunk://#diff-41bcb2b59581c49a58e7d7beb1c0fae6a695faf7774a1b296846e9f5e991ad62R28-R30) [[2]](diffhunk://#diff-41bcb2b59581c49a58e7d7beb1c0fae6a695faf7774a1b296846e9f5e991ad62L37-L39)
* Enhanced error handling during schema parsing by adding custom error messages using `errorMap`. [[1]](diffhunk://#diff-41bcb2b59581c49a58e7d7beb1c0fae6a695faf7774a1b296846e9f5e991ad62L63-R75) [[2]](diffhunk://#diff-41bcb2b59581c49a58e7d7beb1c0fae6a695faf7774a1b296846e9f5e991ad62L77-R113)
* Improved error logging by checking the type of errors and using the centralized `error` formatting.

### Changes to `init` command:

* Added `chalk` import for consistent error and info formatting.
* Defined `error` and `info` formatting constants for use throughout the command.
* Enhanced error handling during schema parsing and initialization, including custom error messages and proper process exit codes. [[1]](diffhunk://#diff-b24496b550631c1972056b1a874202e27304ea177234bf40e1214162efdb661eR54-R64) [[2]](diffhunk://#diff-b24496b550631c1972056b1a874202e27304ea177234bf40e1214162efdb661eL80-R86) [[3]](diffhunk://#diff-b24496b550631c1972056b1a874202e27304ea177234bf40e1214162efdb661eL91-R106) [[4]](diffhunk://#diff-b24496b550631c1972056b1a874202e27304ea177234bf40e1214162efdb661eL108-R133)