### PR TITLE
fix: defer new-system build scripts

### DIFF
--- a/packages/new/system-output/package.json
+++ b/packages/new/system-output/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "node --experimental-strip-types ./scripts/build.ts && prettier --write ./src/generated",
     "lint": "eslint --max-warnings 0 --no-warn-ignored .",
     "check-type": "tsgo --noEmit",
     "test": "pnpm exec vitest run"

--- a/packages/new/system-runtime/package.json
+++ b/packages/new/system-runtime/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "tsdown && node ./scripts/postbuild.mjs",
     "lint": "eslint --max-warnings 0 --no-warn-ignored .",
     "check-type": "tsgo --noEmit",
     "test": "pnpm exec vitest run"


### PR DESCRIPTION
Remove the temporary build scripts from the new system runtime/output packages.

These packages are not ready to participate in the root build yet, and their build wiring was causing the post-merge docs workflow to fail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **Chores**
  * 빌드 스크립트 항목이 제거되었습니다. 내부 빌드 프로세스가 간소화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->