### PR TITLE
fix(actions): run vercel deploy action as composite

### DIFF
--- a/.github/actions/vercel/action.yml
+++ b/.github/actions/vercel/action.yml
@@ -18,11 +18,34 @@ inputs:
     required: false
     default: "--prod"
   workingDir:
-    description: "Optional working directory passed through the workflow."
-    required: false
+    description: "Working directory passed through the workflow."
+    required: true
+outputs:
+  preview-url:
+    description: "Resolved Vercel deployment URL."
+    value: ${{ steps.deploy.outputs.preview-url }}
+  preview-name:
+    description: "Resolved Vercel deployment name."
+    value: ${{ steps.deploy.outputs.preview-name }}
 runs:
-  using: "node20"
-  main: "index.js"
+  using: composite
+  steps:
+    - name: Use Node.js from .nvmrc
+      uses: actions/setup-node@v4
+      with:
+        node-version-file: .nvmrc
+
+    - name: Run Vercel deploy
+      id: deploy
+      shell: bash
+      env:
+        VERCEL_TOKEN: ${{ inputs.vercel-token }}
+        ACTION_GITHUB_TOKEN: ${{ inputs.github-token }}
+        VERCEL_ORG_ID: ${{ inputs.vercel-org-id }}
+        VERCEL_PROJECT_ID: ${{ inputs.vercel-project-id }}
+        VERCEL_ARGS: ${{ inputs.vercel-args }}
+        WORKING_DIR: ${{ inputs.workingDir }}
+      run: node "$GITHUB_ACTION_PATH/index.js"
 branding:
   icon: "triangle"
   color: "blue"

--- a/.github/actions/vercel/index.js
+++ b/.github/actions/vercel/index.js
@@ -16,12 +16,22 @@ import { existsSync } from "node:fs"
 function readInputs() {
   try {
     return {
-      vercelToken: getInput("vercel-token", { required: true }),
-      githubToken: getInput("github-token", { required: true }),
-      vercelOrgId: getInput("vercel-org-id", { required: true }),
-      vercelProjectId: getInput("vercel-project-id", { required: true }),
-      vercelArgs: getInput("vercel-args") || "--prod",
-      workingDir: getInput("workingDir"),
+      vercelToken:
+        process.env.VERCEL_TOKEN ||
+        getInput("vercel-token", { required: true }),
+      githubToken:
+        process.env.ACTION_GITHUB_TOKEN ||
+        getInput("github-token", { required: true }),
+      vercelOrgId:
+        process.env.VERCEL_ORG_ID ||
+        getInput("vercel-org-id", { required: true }),
+      vercelProjectId:
+        process.env.VERCEL_PROJECT_ID ||
+        getInput("vercel-project-id", { required: true }),
+      vercelArgs:
+        process.env.VERCEL_ARGS || getInput("vercel-args") || "--prod",
+      workingDir:
+        process.env.WORKING_DIR || getInput("workingDir", { required: true }),
     }
   } catch (error) {
     setFailed(error instanceof Error ? error.message : String(error))


### PR DESCRIPTION
## Summary
- convert the local Vercel action from a node action to a composite action
- pass workflow inputs through step env so the existing Node entrypoint can keep reading them
- expose preview-url and preview-name outputs from the composite step

## Validation
- pnpm exec prettier --check .github/actions/vercel/action.yml .github/actions/vercel/index.js
- node --check .github/actions/vercel/index.js

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * GitHub Action 워크플로우 업데이트: 작업 디렉토리를 필수 입력값으로 변경했습니다.
  * 배포 미리보기 URL 및 이름 출력값 추가: 워크플로우에서 배포 결과 정보를 직접 활용할 수 있습니다.
  * 환경 변수를 통한 입력 구성 지원 추가: 더 유연한 CI/CD 설정이 가능합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->