### PR TITLE
fix: pass npm token to changeset publish

### DIFF
--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -39,3 +39,4 @@ jobs:
           publish: pnpm ci:publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Pass the existing NPM_TOKEN secret into changesets/action so pnpm ci:publish can authenticate with npm.

## Verification
- git diff --check