### PR TITLE
chore: update github actions to avoid node20 warnings

### DIFF
--- a/.github/actions/playwright/action.yml
+++ b/.github/actions/playwright/action.yml
@@ -11,7 +11,7 @@ runs:
       id: playwright-version
 
     - name: Cache Playwright Browsers for Playwright's Version
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         # https://playwright.dev/docs/browsers#managing-browser-binaries
         path: ~/.cache/ms-playwright

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
     - name: Cache turbo build setup
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: .turbo
         key: ${{ runner.os }}-turbo-${{ github.sha }}
@@ -13,10 +13,10 @@ runs:
           ${{ runner.os }}-turbo-
 
     - name: Install pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@v4.4.0
 
     - name: Use Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version-file: .nvmrc
         cache: "pnpm"

--- a/.github/actions/vercel/action.yml
+++ b/.github/actions/vercel/action.yml
@@ -30,11 +30,6 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Use Node.js from .nvmrc
-      uses: actions/setup-node@v4
-      with:
-        node-version-file: .nvmrc
-
     - name: Run Vercel deploy
       id: deploy
       shell: bash

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: checkout branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 
@@ -27,13 +27,13 @@ jobs:
         run: pnpm turbo build
 
       - name: Upload Storybook artifact for Chromatic
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ui-artifact
           path: packages/ui/storybook-static
 
       - name: Upload Docs artifact for AWS
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: docs-artifact
           path: app/docs/out
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 
@@ -51,7 +51,7 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Download  Docs artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: docs-artifact
           path: app/docs/out

--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: pnpm setup
         uses: ./.github/actions/setup

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: ci setup
         uses: ./.github/actions/setup

--- a/.github/workflows/tokens.yml
+++ b/.github/workflows/tokens.yml
@@ -10,8 +10,8 @@ jobs:
   createPullRequest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v4.4.0
 
       # 디자인 파일 변환 후 생성된 파일도 push해서 main 브랜치로 병합하는 PR을 생성
       - name: install dependencies


### PR DESCRIPTION
## Summary
- GitHub Actions 버전을 Node24 런타임 지원 최소 버전으로 최신화합니다.
- 중복 Node setup을 제거해 Node20 warning 발생 경로를 줄입니다.

## Test Plan
- Node20 action tag 검출 확인
- YAML 파싱 확인
- Prettier 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * GitHub Actions 워크플로우 및 자동화 도구의 버전을 최신으로 업데이트하여 빌드 및 배포 파이프라인의 안정성을 개선했습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jongh-design-system/jds/pull/193)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->