### PR TITLE
feat(code-review): 안전한 Codex 리뷰 workflow 추가

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -1,0 +1,69 @@
+name: codex review
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    if: ${{ github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository }}
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: checkout reviewer
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: reviewer
+          persist-credentials: false
+
+      - name: checkout pull request target
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: target
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: fetch target base
+        working-directory: target
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: git fetch --no-tags origin "$BASE_REF"
+
+      - name: remove target checkout credentials
+        working-directory: target
+        run: git config --local --unset-all http.https://github.com/.extraheader || true
+
+      - name: setup node
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: reviewer/.nvmrc
+
+      - name: install codex
+        run: npm install -g @openai/codex
+
+      - name: restore codex auth
+        env:
+          CODEX_AUTH_JSON_B64: ${{ secrets.CODEX_AUTH_JSON_B64 }}
+        run: |
+          test -n "$CODEX_AUTH_JSON_B64"
+          mkdir -p ~/.codex
+          printf '%s' "$CODEX_AUTH_JSON_B64" | base64 -d > ~/.codex/auth.json
+          chmod 600 ~/.codex/auth.json
+
+      - name: run codex review
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >
+          node "$GITHUB_WORKSPACE/reviewer/code-review/src/cli.js"
+          --repo "$GITHUB_WORKSPACE/target"
+          --event "$GITHUB_EVENT_PATH"
+          --base "origin/$BASE_REF"
+          --head HEAD


### PR DESCRIPTION
## 의도

#198에서 추가한 `code-review` 로직을 GitHub Actions에서 자동 실행합니다.

이 PR의 핵심은 Codex/GitHub credential을 가진 상태에서 PR head 코드를 실행하지 않는 것입니다. workflow는 `pull_request_target`에서 base branch의 reviewer 코드를 실행하고, PR head는 `target/`에 checkout해서 diff를 읽는 대상으로만 둡니다.

## 구현 요약

- `pull_request_target`으로 base branch workflow를 사용합니다.
- fork PR은 secret 때문에 실행하지 않습니다.
- base branch 코드는 `reviewer/`에 checkout합니다.
- PR head 코드는 `target/`에 checkout합니다.
- base fetch 후 target checkout credential을 제거합니다.
- Codex auth는 credential 제거 이후 복원합니다.
- 실행은 `reviewer/code-review/src/cli.js`로 하고, 리뷰 대상 repo만 `--repo target`으로 넘깁니다.
- `GITHUB_TOKEN`은 CLI posting 단계에만 넘기고, Codex subprocess에는 전달되지 않습니다.

## 리뷰 요청

다음 보안 경계가 코드상으로 맞는지 봐주세요.

- PR head의 `code-review` 파일이 실행되지 않는가
- GitHub checkout credential이 Codex 실행 전에 제거되는가
- Codex auth 복원 시점이 credential 제거 이후인가
- `GITHUB_TOKEN`과 Codex subprocess 환경이 분리되는가
- fork PR에서 secret workflow가 실행되지 않는가

## 검증

- `node --test code-review/test/*.test.js`
- 16개 테스트 통과