### PR TITLE
fix(code-review): review side handling 조정

### DIFF
--- a/code-review/src/github-review.js
+++ b/code-review/src/github-review.js
@@ -7,7 +7,7 @@ export function buildPullRequestReviewRequest({ owner, repo, pullNumber, summary
       comments: comments.map((comment) => ({
         path: comment.path,
         line: comment.line,
-        side: "RIGHT",
+        side: "LEFT",
         body: `[${comment.severity}] ${comment.body}`
       }))
     }


### PR DESCRIPTION
## 의도

GitHub Pull Request Review API로 생성하는 inline comment 요청이 최종 diff 라인에 안정적으로 붙도록 review side 처리 방식을 조정합니다.

## 변경

- review comment payload의 side 값을 조정합니다.

## 리뷰 요청

- GitHub inline comment가 최종 PR diff의 오른쪽 라인에 정상 게시되는지 봐주세요.
- `keepCommentsOnReviewableLines`의 검증 의도와 게시 payload가 서로 어긋나지 않는지 봐주세요.