### PR TITLE
test: codex json events smoke

### DIFF
--- a/code-review/test/fixtures/codex-json-events-smoke.js
+++ b/code-review/test/fixtures/codex-json-events-smoke.js
@@ -1,0 +1,3 @@
+export function averageDuration(durations) {
+  return durations.reduce((total, duration) => total + duration, 0) / durations.length
+}


### PR DESCRIPTION
이 PR은 codex review JSON event logging smoke test입니다.

리뷰 의도:
- 새 averageDuration helper는 숫자 배열의 평균을 반환해야 합니다.
- 빈 배열이 들어오면 NaN이나 Infinity가 아니라 0을 반환해야 합니다.
- 이 PR은 실제 merge 대상이 아니며, Codex JSONL event artifact와 usage summary 확인용입니다.