### PR TITLE
feat: add component guide registry and upgrade docs to Next.js 16

### DIFF
--- a/app/docs/eslint.config.mjs
+++ b/app/docs/eslint.config.mjs
@@ -2,7 +2,15 @@ import { config } from "@jongh/eslint/next-js"
 
 /** @type {import("eslint").Linter.Config} */
 export default [
-  { ignores: ["public/**"] },
+  {
+    ignores: [
+      ".next/**",
+      ".velite/**",
+      "out/**",
+      "public/**",
+      "styled-system/**",
+    ],
+  },
   {
     files: ["**/*.{js,jsx,ts,tsx}"],
     settings: {

--- a/app/docs/next-env.d.ts
+++ b/app/docs/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+import "./.next/types/routes.d.ts"
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/app/docs/next.config.mjs
+++ b/app/docs/next.config.mjs
@@ -1,4 +1,4 @@
-const isDev = process.argv.indexOf("dev") !== -1
+const isDev = process.env.NODE_ENV === "development"
 const isBuild = process.argv.indexOf("build") !== -1
 if (!process.env.VELITE_STARTED && (isDev || isBuild)) {
   process.env.VELITE_STARTED = "1"

--- a/app/docs/package.json
+++ b/app/docs/package.json
@@ -5,9 +5,9 @@
   "type": "module",
   "scripts": {
     "prepare": "panda codegen && velite build",
-    "dev": "next dev --turbopack",
+    "dev": "next dev",
     "start": "next start",
-    "lint": "next lint --fix",
+    "lint": "eslint . --fix",
     "build": "next build",
     "check-type": "tsgo --noEmit",
     "transform-icon": "npx tsx ./scripts/transformIcon.ts && npx prettier --write ./src/components/icons/*.tsx"
@@ -15,12 +15,12 @@
   "dependencies": {
     "lucide-react": "^0.475.0",
     "motion": "^12.4.10",
-    "next": "15.1.4",
+    "next": "16.2.10",
     "next-themes": "^0.4.4",
     "panda-animation": "workspace:*",
     "radix-ui": "^1.1.2",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7"
   },
   "devDependencies": {
     "@jongh/eslint": "workspace:*",
@@ -32,8 +32,8 @@
     "@svgr/plugin-prettier": "^8.1.0",
     "@svgr/plugin-svgo": "^8.1.0",
     "@types/node": "^20",
-    "@types/react": "^19",
-    "@types/react-dom": "^19",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
     "velite": "^0.2.2",
     "@pandacss/dev": "catalog:"
   }

--- a/app/docs/tsconfig.json
+++ b/app/docs/tsconfig.json
@@ -11,7 +11,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {
@@ -30,7 +30,8 @@
     "**/*.ts",
     "**/*.tsx",
     "**/*.mdx",
-    ".next/types/**/*.ts"
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
   ],
   "exclude": ["node_modules"]
 }

--- a/lint-staged.config.cjs
+++ b/lint-staged.config.cjs
@@ -21,7 +21,7 @@ module.exports = {
   "*.{ts,tsx,css,md}": "prettier --write",
   ...typeCheckConfigs,
   "./app/docs/**/*.{ts,tsx}": (filename) => [
-    `pnpm --filter docs lint --file ${filename.join(" ")}`,
+    `pnpm --filter docs lint ${filename.join(" ")}`,
     `pnpm --filter docs check-type`,
   ],
 }

--- a/packages/cli/src/build-script.ts
+++ b/packages/cli/src/build-script.ts
@@ -6,7 +6,7 @@ import { Project } from "ts-morph"
 import { fileURLToPath } from "url"
 import { z } from "zod"
 
-import { fileSchema, styleSchema } from "./common/types"
+import { fileSchema, guideRegistrySchema, styleSchema } from "./common/types"
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
@@ -59,6 +59,7 @@ export async function handleRegistryCommand(
       for (const component of components) {
         console.log(`\n🔄 ${component} 처리 중...`)
         await createRegistryFile(component)
+        await createGuideRegistryFile(component)
       }
       await createPresetFile()
       await createTailwindTokenFile()
@@ -66,6 +67,7 @@ export async function handleRegistryCommand(
     } else {
       console.log(`🔄 ${component} 컴포넌트의 Registry 파일을 생성합니다.`)
       await createRegistryFile(component!)
+      await createGuideRegistryFile(component!)
       console.log(`✅ ${component} Registry 파일 생성이 완료되었습니다!`)
     }
   } catch (e) {
@@ -130,6 +132,23 @@ export async function createRegistryFile(component: string) {
   await fs.writeFile(
     path.join(TARGET_PATH, `${component.toLowerCase()}.json`),
     stringifiedFileContent,
+  )
+}
+
+export async function createGuideRegistryFile(component: string) {
+  const guidePath = path.join(UI_WORKSPACE_PATH, component, "guide.md")
+  if (!(await fs.pathExists(guidePath))) {
+    return
+  }
+
+  const guide = guideRegistrySchema.parse({
+    name: component,
+    content: await fs.readFile(guidePath, "utf-8"),
+  })
+
+  await fs.outputFile(
+    path.join(TARGET_PATH, "guides", `${component.toLowerCase()}.json`),
+    JSON.stringify(guide),
   )
 }
 

--- a/packages/cli/src/commands/guide/index.ts
+++ b/packages/cli/src/commands/guide/index.ts
@@ -1,0 +1,32 @@
+import { Command } from "commander"
+
+import { guideRegistrySchema } from "@/common/types"
+
+const BASE_URL = (
+  process.env.JDS_REGISTRY_URL ?? "https://jds-docs.vercel.app"
+).replace(/\/$/, "")
+
+export const guideCommand = new Command()
+  .name("guide")
+  .description("Print component authoring guidance")
+  .argument("<component>")
+  .action(async (component: string) => {
+    const name = component.trim().toLowerCase()
+
+    try {
+      const response = await fetch(`${BASE_URL}/guides/${name}.json`)
+      if (!response.ok) {
+        throw new Error(
+          `Failed to fetch guide for ${name}: ${response.status} ${response.statusText}`,
+        )
+      }
+
+      const guide = guideRegistrySchema.parse(await response.json())
+      process.stdout.write(guide.content)
+    } catch (error) {
+      process.stderr.write(
+        `${error instanceof Error ? error.message : String(error)}\n`,
+      )
+      process.exitCode = 1
+    }
+  })

--- a/packages/cli/src/common/types/index.ts
+++ b/packages/cli/src/common/types/index.ts
@@ -47,6 +47,11 @@ export const registrySchema = z.object({
   ),
 })
 
+export const guideRegistrySchema = z.object({
+  name: z.string(),
+  content: z.string(),
+})
+
 export const presetSchema = z.object({
   name: z.string(),
   dependencies: z.array(z.string()).optional(),

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -3,6 +3,7 @@
 import { Command } from "commander"
 
 import { addCommand } from "@/commands/add"
+import { guideCommand } from "@/commands/guide"
 import { initCommand } from "@/commands/init"
 import { mcpCommand } from "@/commands/mcp"
 import { codemodCommand } from "@/commands/radix-import"
@@ -16,6 +17,7 @@ async function main() {
   cmd
     .addCommand(initCommand)
     .addCommand(addCommand)
+    .addCommand(guideCommand)
     .addCommand(codemodCommand)
     .addCommand(mcpCommand)
     .parse()

--- a/packages/cli/src/test/guide.test.ts
+++ b/packages/cli/src/test/guide.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, test, vi } from "vitest"
+
+import { guideCommand } from "@/commands/guide"
+
+const GUIDE = {
+  name: "button",
+  content: "# Button\n\nComponent authoring guidance.\n",
+}
+
+describe("guide command", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  test("prints the requested component guide as Markdown", async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve(
+        new Response(JSON.stringify(GUIDE), {
+          headers: { "content-type": "application/json" },
+          status: 200,
+        }),
+      ),
+    )
+    vi.stubGlobal("fetch", fetchMock)
+
+    const write = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true)
+
+    await guideCommand.parseAsync(["node", "guide", "Button"])
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://jds-docs.vercel.app/guides/button.json",
+    )
+    expect(write).toHaveBeenCalledWith(GUIDE.content)
+  })
+})

--- a/packages/ui/src/component/accordion/guide.md
+++ b/packages/ui/src/component/accordion/guide.md
@@ -1,0 +1,117 @@
+---
+name: accordion
+platform: web
+---
+
+# Accordion
+
+## 역할
+
+서로 관련된 콘텐츠 섹션의 제목을 먼저 보여 주고, 사용자가 필요한 섹션을 펼치거나 접을 수 있게 한다. 페이지의 주요 탐색이나 단계형 작업 흐름을 대신하지 않으며, 대부분의 내용을 동시에 읽어야 하는 경우에는 일반적인 제목과 본문 구조가 더 적합하다. [USWDS는 사용자가 일부 정보만 필요하거나 공간이 제한된 경우를 적합한 조건으로 제시한다](https://designsystem.digital.gov/components/accordion/).
+
+## 보장해야 하는 계약
+
+| 조건                                      | 규칙                                                                                                                        | 근거                                                                                                                                                                                                            |
+| ----------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 항상                                      | 각 섹션 제목은 실행 가능한 컨트롤이며, 접근 가능한 이름이 섹션의 목적을 설명해야 한다.                                      | [WAI-ARIA Accordion Pattern (informative)](https://www.w3.org/WAI/ARIA/apg/patterns/accordion/)                                                                                                                 |
+| 항상                                      | 트리거의 펼침 상태는 `aria-expanded`와 실제 패널 가시성이 일치해야 하고, 제어 대상과의 관계를 프로그램적으로 제공해야 한다. | [`aria-expanded` 명세](https://www.w3.org/TR/wai-aria/#aria-expanded), [`aria-controls` 명세](https://www.w3.org/TR/wai-aria/#aria-controls)                                                                    |
+| 제목 계층을 표현하는 경우                 | 트리거를 감싸는 제목의 수준은 컴포넌트 모양이 아니라 문서의 정보 구조에서 결정한다.                                         | [WAI-ARIA Accordion Pattern (informative)](https://www.w3.org/WAI/ARIA/apg/patterns/accordion/), [Scottish Government Design System](https://designsystem.gov.scot/components/accordion)                        |
+| 패널이 접힌 경우                          | 숨겨진 패널의 컨트롤이 키보드 순서에 남거나 보조 기술에 펼쳐진 콘텐츠처럼 노출되지 않아야 한다.                             | [`hidden` 속성에 관한 HTML 표준](https://html.spec.whatwg.org/multipage/interaction.html#the-hidden-attribute), [WAI-ARIA Accordion Pattern (informative)](https://www.w3.org/WAI/ARIA/apg/patterns/accordion/) |
+| 트리거를 사용자 정의 요소로 구현하는 경우 | `Enter`와 `Space`로 상태를 바꿀 수 있어야 한다. 네이티브 `button`을 사용하면 이 기본 의미와 입력 동작을 우선 활용한다.      | [HTML `button` 요소](https://html.spec.whatwg.org/multipage/form-elements.html#the-button-element), [WAI-ARIA Accordion Pattern (informative)](https://www.w3.org/WAI/ARIA/apg/patterns/accordion/)             |
+| 상태를 시각적으로 표현하는 경우           | 색상이나 회전 아이콘 하나에만 의존하지 않고, 상태와 키보드 포커스를 구분 가능하게 표현한다.                                 | [WCAG 2.2: Use of Color, Focus Visible, Name·Role·Value](https://www.w3.org/TR/WCAG22/)                                                                                                                         |
+
+APG는 WAI-ARIA 명세 자체가 아니라 **informative 작성 지침**이며, 예제 코드는 프로덕션 사용을 보증하지 않는다. 실제 브라우저와 보조 기술 조합에서 별도로 검증한다. [APG Accordion Example의 사용 전 안내](https://www.w3.org/WAI/ARIA/apg/patterns/accordion/examples/accordion/)
+
+## 프로젝트에서 결정할 항목
+
+| 결정                                | 적용 조건                               | 판단에 사용하는 정보                                |
+| ----------------------------------- | --------------------------------------- | --------------------------------------------------- |
+| 한 번에 열 수 있는 섹션 수          | 둘 이상의 섹션이 존재할 때              | 콘텐츠 비교 필요성, 작업 연속성, 제품 상태 모델     |
+| 모든 섹션을 접을 수 있는지          | 단일 펼침 모델을 사용할 때              | 빈 상태 허용 여부, 반드시 노출해야 하는 콘텐츠      |
+| 패널에 `region`을 부여할지          | 패널이 독립적인 랜드마크로 유용할 때    | 패널 수, 페이지 랜드마크 밀도, 콘텐츠 길이          |
+| 방향키·`Home`·`End` 탐색을 제공할지 | 헤더가 많고 연속 탐색의 이점이 있을 때  | 키보드 사용 빈도, 플랫폼 관례, 구현 복잡도          |
+| 초기 펼침 상태                      | 서버 렌더링 또는 복원 상태가 있을 때    | 주요 콘텐츠 우선순위, URL·세션 상태, 오류 복구      |
+| 펼침·접힘 모션                      | 패널 크기가 변할 때                     | Motion Foundation, 콘텐츠 길이, reduced-motion 정책 |
+| 전체 펼치기·접기 제어               | 섹션 수가 많고 전체 검토 작업이 있을 때 | 사용자 조사, 반복 작업 비용, 분석 데이터            |
+
+## 토큰 결정 지도
+
+```yaml
+root:
+  gap: spacing
+
+item:
+  border-color: color
+  border-width: border
+  border-radius: radius
+
+trigger:
+  color: color
+  background-color: color
+  typography: typography
+  padding-block: spacing
+  padding-inline: spacing
+  gap: spacing
+  min-block-size: sizing
+
+indicator:
+  color: color
+  size: sizing
+  transition-duration: motion
+  transition-timing-function: motion
+
+panel:
+  color: color
+  background-color: color
+  typography: typography
+  padding-block: spacing
+  padding-inline: spacing
+
+focus:
+  outline-color: color
+  outline-width: border
+  outline-offset: spacing
+
+motion:
+  duration: motion
+  easing: motion
+```
+
+## 엔지니어링 지식
+
+### 의미와 동작
+
+제목, 트리거, 패널의 관계를 데이터 상태 하나에서 파생해 시각 상태와 접근성 상태가 어긋나지 않게 한다. 상호 배타적 펼침과 다중 펼침은 서로 다른 제품 계약이므로 컴포넌트가 임의로 혼합하지 않는다. 단순한 단일 disclosure만 필요하다면 네이티브 [`details`와 `summary`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/details)가 더 작은 구현이 될 수 있다.
+
+### 레이아웃
+
+트리거 전체를 일관된 입력 영역으로 만들고, 긴 제목·텍스트 확대·번역으로 줄바꿈되어도 표시자와 제목이 겹치지 않게 한다. 열린 패널의 높이를 임의로 제한하지 않으며, 제품 컨테이너가 높이를 제한한다면 내부 스크롤과 페이지 스크롤의 관계를 명시한다. [Carbon은 열린 패널에 고정 최대 높이를 두지 않고 너비를 문맥에 맞추도록 안내한다](https://carbondesignsystem.com/components/accordion/style/).
+
+### 접근성
+
+트리거는 일반 페이지 `Tab` 순서에 포함하고, 패널 내부의 상호작용 요소도 펼쳐진 동안 자연스러운 문서 순서를 유지한다. 방향키 탐색은 APG의 선택적 권고이며 필수 키보드 계약으로 오해하지 않는다. 아이콘은 상태의 중복 장식이면 접근성 이름에 불필요하게 포함하지 않는다. [APG Accordion Pattern (informative)](https://www.w3.org/WAI/ARIA/apg/patterns/accordion/)
+
+### 렌더링과 브라우저
+
+서버 렌더링된 초기 상태와 클라이언트 초기화 상태가 같아야 한다. 스크립트 실패 시 핵심 콘텐츠가 영구적으로 사라지지 않는 점진적 향상을 고려한다. 높이 애니메이션을 위해 콘텐츠를 계속 노출하는 구현은 접힌 패널의 focusability와 접근성 트리 상태를 별도로 관리해야 한다. 사용자가 동작 감소를 요청하면 불필요한 크기·회전 애니메이션을 줄인다. [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
+
+## 검증 관점
+
+- 트리거의 이름만 읽어도 대응하는 섹션을 예측할 수 있는가
+- 포인터, `Enter`, `Space`가 동일한 펼침 상태를 만드는가
+- `aria-expanded`와 실제 패널 표시 상태가 항상 일치하는가
+- 접힌 패널 내부 요소로 포커스가 이동하지 않는가
+- 제목 수준이 주변 문서 구조와 자연스럽게 이어지는가
+- 긴 제목, 확대, 좁은 화면에서 제목과 표시자가 겹치지 않는가
+- 모션 감소 설정에서도 상태 변화가 즉시 이해되는가
+
+## 출처
+
+- [WAI-ARIA 1.2](https://www.w3.org/TR/wai-aria/)
+- [WAI-ARIA APG Accordion Pattern (informative)](https://www.w3.org/WAI/ARIA/apg/patterns/accordion/)
+- [APG Accordion Example 사용 전 안내](https://www.w3.org/WAI/ARIA/apg/patterns/accordion/examples/accordion/)
+- [HTML Standard: `button`](https://html.spec.whatwg.org/multipage/form-elements.html#the-button-element)
+- [WCAG 2.2](https://www.w3.org/TR/WCAG22/)
+- [USWDS Accordion](https://designsystem.digital.gov/components/accordion/)
+- [Carbon Accordion](https://carbondesignsystem.com/components/accordion/style/)
+- [Scottish Government Design System Accordion](https://designsystem.gov.scot/components/accordion)

--- a/packages/ui/src/component/animateButton/guide.md
+++ b/packages/ui/src/component/animateButton/guide.md
@@ -1,0 +1,109 @@
+---
+name: animateButton
+platform: web
+---
+
+# Animate Button
+
+## 역할
+
+Animate Button은 버튼의 기존 의미와 동작을 보존하면서 사용자의 의도적인 입력, 실행 가능 상태 또는 작업 결과에 대한 짧은 시각 피드백을 모션으로 보강한다. 모션은 동작 자체가 아니며, 애니메이션이 실행되지 않거나 중단되어도 버튼의 기능과 상태 전달은 완전해야 한다.
+
+## 보장해야 하는 계약
+
+| 조건                                        | 규칙                                                                                                                             | 근거                                                                                                                                                      |
+| ------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 항상                                        | 애니메이션 래퍼가 버튼의 역할, 접근 가능한 이름, 키보드 동작, 포커스, 비활성 상태를 바꾸거나 중복된 대화형 요소를 만들지 않는다. | 사용자 인터페이스 컴포넌트의 이름, 역할, 상태와 값은 프로그램적으로 결정 가능해야 한다. [S1]                                                              |
+| 입력 피드백을 제공할 때                     | 피드백은 사용자의 실제 의도와 연결되고 즉시 시작되며, 버튼의 본래 동작 완료를 애니메이션 종료에 의존시키지 않는다.               | Carbon은 목적 있는 모션과 사용자 입력에 대한 즉각적인 피드백을 평가 기준으로 둔다. [S2]                                                                   |
+| hover로 모션을 유발할 때                    | hover를 지원하지 않는 입력에서도 버튼의 상태와 동작을 온전히 알 수 있어야 하며, hover 모션을 유일한 피드백으로 사용하지 않는다.  | `hover` 미디어 기능은 주 입력 장치가 편리하게 hover할 수 있는지를 구분하며 많은 모바일 입력은 그렇지 않다. [S3]                                           |
+| 사용자가 감소된 모션을 선호할 때            | 비필수 이동과 크기 변화는 제거하거나 정적인 상태 변화로 대체한다. 기능, 결과, 오류 정보는 그대로 유지한다.                       | `prefers-reduced-motion`은 비필수 모션을 제거·감소·대체하려는 사용자 선호를 전달하며 [S4], 상호작용 유발 비필수 애니메이션은 비활성화 가능해야 한다. [S5] |
+| 모션 도중 새 입력이나 반대 상태가 발생할 때 | 오래된 애니메이션을 무조건 대기열에 쌓지 않는다. 현재 시각 상태에서 새 의도를 반영하도록 취소, 대체 또는 자연스럽게 전환한다.    | Web Animations API는 실행 중 애니메이션을 취소하고 효과를 제거하는 제어 모델을 제공한다. [S6]                                                             |
+| 모션이 상태나 결과를 강조할 때              | 의미를 모션에만 맡기지 않고 상태 속성, 텍스트, 색 또는 아이콘 등 프로젝트가 정한 정적 표현과 함께 전달한다.                      | 감소된 모션에서도 같은 메시지를 정적으로 전달할 대안이 필요하다는 Carbon 지침과 일치한다. [S2]                                                            |
+| 버튼이 비활성 또는 처리 중일 때             | 애니메이션이 실제 실행 가능 여부와 모순되는 affordance를 만들지 않는다. 반복 입력 허용 여부는 제품 동작 계약이 결정한다.         | 컴포넌트 상태는 프로그램적으로 결정 가능해야 한다. [S1]                                                                                                   |
+
+## 프로젝트에서 결정할 항목
+
+| 결정                          | 적용 조건                         | 판단에 사용하는 정보                                      |
+| ----------------------------- | --------------------------------- | --------------------------------------------------------- |
+| 모션이 해결하는 사용자 문제   | 모션을 추가할 때마다              | User journey, Interaction model, Information hierarchy    |
+| 유발 시점                     | 입력 또는 상태 변화에 반응할 때   | Pointer, Keyboard, Touch, Product behavior                |
+| 피드백의 시각적 속성          | 모션이 유효하다고 판단될 때       | Motion foundation, Brand expression, Component geometry   |
+| 지속 시간과 easing            | 모션을 사용할 때                  | Motion foundation, Travel distance, Interaction frequency |
+| 반복 입력과 interruption 정책 | 연속 입력이 가능할 때             | Action idempotency, Async behavior, State machine         |
+| 감소된 모션 대체 표현         | 비필수 모션이 있을 때             | Accessibility preference, Color, State messaging          |
+| 성공, 오류, 처리 중 표현      | 버튼이 실행 결과를 직접 나타낼 때 | Product feedback model, Status components, Accessibility  |
+| 표현적 모션의 허용 범위       | 중요한 순간을 강조하려 할 때      | Brand, Frequency, User task criticality                   |
+
+## 토큰 결정 지도
+
+```yaml
+feedback:
+  transition-duration: motion
+  transition-timing-function: motion
+  transform-distance: motion
+  transform-scale: motion
+  opacity: motion
+
+state:
+  color: color
+  background-color: color
+  border-color: color
+
+focus:
+  outline-color: color
+  outline-width: border
+  outline-offset: spacing
+
+reduced-motion:
+  transition-duration: motion
+  opacity: motion
+```
+
+이 지도는 모션 값을 직접 정하지 않는다. `state`와 `focus`는 기반 Button의 결정이 우선하며 Animate Button이 별도 시각 체계를 만들지 않는다.
+
+## 엔지니어링 지식
+
+### 의미와 동작
+
+Animate Button은 Button의 표현 계층이다. 내부에 별도의 버튼을 중첩하거나 애니메이션을 위해 의미 없는 요소를 실제 입력 대상으로 바꾸지 않는다. 클릭, 키보드 활성화, 폼 제출은 기반 Button의 계약을 그대로 따른다.
+
+모션은 “입력을 받았다”, “실행할 수 없다”, “결과가 도착했다” 중 무엇을 나타내는지 하나의 의도를 가져야 한다. hover는 탐색적 포인터 상태이고 activation은 실제 실행 의도이므로 같은 의미로 취급하지 않는다. 결과 모션이 필요하면 비동기 상태 머신에서 결과를 받아 시작하며, 단지 포인터가 떠났다는 이유로 성공이나 오류 정보가 사라지지 않게 한다.
+
+### 레이아웃
+
+시각적 이동이나 크기 변화가 주변 문서 흐름을 재배치하지 않도록 최종 버튼의 레이아웃 공간을 유지한다. 변형된 버튼이 인접 컨트롤을 가리거나 컨테이너에 잘리거나, 포커스 표시가 잘리지 않는지 확인한다. 버튼의 시각적 위치를 크게 이동시키는 피드백은 사용자가 누르려는 목표와 표시 위치를 어긋나게 할 수 있으므로 제품 목적 없이 사용하지 않는다.
+
+처리 중 레이블이나 아이콘이 바뀌는 경우에도 버튼의 폭 변화와 주변 레이아웃 이동을 별도로 평가한다. 모션은 레이아웃 안정성 문제를 숨기는 수단이 아니다.
+
+### 접근성
+
+감소된 모션 선호에서는 단순히 duration만 짧게 만드는 것으로 충분한지 판단한다. 이동과 확대 자체가 문제라면 이를 제거하고 색, 테두리, 아이콘 또는 즉시 완료 상태 같은 정적 피드백으로 바꾼다. [W3C의 상호작용 유발 애니메이션 설명][S5]은 비필수 모션을 끌 수 있어야 한다고 명시한다.
+
+애니메이션은 포커스 표시를 대신하지 않는다. 시각 효과가 접근 가능한 이름이나 live region을 반복 변경해 불필요한 재발표를 만들지 않게 한다. 반복적이거나 자동으로 계속되는 효과로 확장한다면 자동 시작 모션에 대한 pause, stop, hide 요구도 별도로 적용한다. [S7]
+
+### 렌더링과 브라우저
+
+실행 중 애니메이션을 명시적으로 추적해 새 의도에서 이전 효과를 취소하거나 대체한다. 취소 시 완료 promise가 거부될 수 있으므로 취소를 오류 결과로 오인하지 않는다. [S6] 컴포넌트가 제거되거나 비활성화되거나 감소된 모션 설정이 바뀔 때 남아 있는 효과와 완료 콜백을 정리한다.
+
+hover 지원 여부는 viewport 크기로 추정하지 않는다. 브라우저가 제공하는 입력 기능 질의를 사용하고 키보드, 터치, 포인터 각각에서 실제 상태 전이를 확인한다. 성능이 낮은 장치에서도 입력 처리가 애니메이션 프레임에 막히지 않아야 한다.
+
+## 검증 관점
+
+- 모션을 완전히 끈 상태에서도 버튼의 실행, 결과, 오류와 비활성 상태를 이해할 수 있는가
+- 키보드, 터치, 마우스 입력에서 같은 기능이 동작하고 hover가 유일한 피드백이 되지 않는가
+- 빠르게 반복 입력하거나 반대 상태로 바꿀 때 오래된 애니메이션이 쌓이거나 뒤늦게 재생되지 않는가
+- 애니메이션 완료 전에 버튼을 제거하거나 비활성화해도 오래된 콜백이 상태를 덮어쓰지 않는가
+- 시각적 이동과 크기 변화가 인접 컨트롤, 포커스 표시, hit area를 가리거나 잘라내지 않는가
+- 감소된 모션 설정을 런타임에 바꿔도 기능과 최종 상태가 보존되는가
+- 애니메이션 래퍼가 중첩 버튼, 중복 포커스 정지점, 중복 accessible name을 만들지 않는가
+- 처리 중 반복 실행 정책과 실제 버튼 활성 상태가 일치하는가
+
+## 출처
+
+- [S1] [WCAG 2.2, Success Criterion 4.1.2 Name, Role, Value](https://www.w3.org/TR/WCAG22/#name-role-value)
+- [S2] [Carbon Design System, Motion](https://carbondesignsystem.com/elements/motion/overview/)
+- [S3] [MDN, `hover` media feature](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/%40media/hover)
+- [S4] [MDN, `prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/%40media/prefers-reduced-motion)
+- [S5] [W3C WAI, Understanding SC 2.3.3 Animation from Interactions](https://www.w3.org/WAI/WCAG22/Understanding/animation-from-interactions)
+- [S6] [MDN, `Animation.cancel()`](https://developer.mozilla.org/en-US/docs/Web/API/Animation/cancel)
+- [S7] [W3C WAI, Understanding SC 2.2.2 Pause, Stop, Hide](https://www.w3.org/WAI/WCAG22/Understanding/pause-stop-hide)

--- a/packages/ui/src/component/animateText/guide.md
+++ b/packages/ui/src/component/animateText/guide.md
@@ -1,0 +1,116 @@
+---
+name: animateText
+platform: web
+---
+
+# Animate Text
+
+## 역할
+
+Animate Text는 실제 텍스트의 의미, 읽기 순서와 레이아웃을 보존하면서 등장이나 상태 전환의 관계를 모션으로 보강한다. 글자, 단어 또는 시각적 줄 단위 효과는 조건부 표현 방식이며, 원문을 대체하는 새로운 콘텐츠 구조가 아니다.
+
+## 보장해야 하는 계약
+
+| 조건                                                        | 규칙                                                                                                                                                           | 근거                                                                                                                                   |
+| ----------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| 항상                                                        | 애니메이션 유무와 관계없이 동일한 원문, 언어, 의미 구조와 읽기 순서를 제공한다. 텍스트를 이미지나 모션 효과에만 담지 않는다.                                   | CSS로 실제 텍스트의 구조와 표현을 분리하면 사용자가 텍스트 표현을 조정할 수 있다. [S1]                                                 |
+| 텍스트를 단위별로 분절할 때                                 | 시각적 wrapper가 원문의 공백, 구두점, 단어 순서와 접근 가능한 문자열을 바꾸거나 중복 발표를 만들지 않는다.                                                     | WCAG는 정보와 관계가 프로그램적으로 결정되거나 텍스트로 제공되어야 한다고 요구한다. [S2]                                               |
+| 글자 단위로 분절할 때                                       | UTF-16 코드 단위가 아니라 사용자에게 하나의 문자로 인식되는 grapheme 경계를 고려한다.                                                                          | 여러 코드 포인트로 구성된 emoji 등은 단순 문자열 분할로 깨질 수 있으며 `Intl.Segmenter`가 grapheme 단위 분절을 제공한다. [S3]          |
+| 단어 또는 줄 단위로 분절할 때                               | locale과 실제 레이아웃에 따라 경계가 달라질 수 있음을 전제로 한다. 소스의 공백만으로 모든 언어의 단어 경계를 추정하거나 고정된 줄 경계를 영구 사용하지 않는다. | 국제화 API의 분절은 locale에 맞는 문자열 경계를 다루며 [S3], 사용자 텍스트 간격 변경에서도 콘텐츠 손실이나 겹침이 없어야 한다. [S4]    |
+| 사용자가 감소된 모션을 선호할 때                            | 원문과 최종 시각 상태를 즉시 제공하고 비필수 이동, 확대, 순차 지연을 제거하거나 정적인 표현으로 대체한다.                                                      | `prefers-reduced-motion`은 비필수 모션의 제거·감소·대체 선호를 전달하며 [S5], 상호작용 유발 비필수 모션은 비활성화 가능해야 한다. [S6] |
+| 텍스트가 자동으로 등장할 때                                 | 읽기를 모션 완료에 의존시키지 않는다. 자동 모션이 길게 지속되거나 다른 콘텐츠와 병행된다면 사용자가 pause, stop 또는 hide할 수 있어야 하는 조건을 평가한다.    | 자동 시작해 일정 시간 이상 다른 콘텐츠와 함께 움직이는 정보에는 pause, stop 또는 hide 메커니즘이 필요하다. [S7]                        |
+| 모션 중 콘텐츠, locale, viewport 또는 사용자 설정이 바뀔 때 | 이전 애니메이션을 정리하고 최신 원문과 레이아웃에 맞는 최종 상태를 보존한다. 오래된 분절이나 완료 콜백이 새 콘텐츠를 덮지 않는다.                              | Web Animations API는 실행 중 효과를 취소하는 제어 모델을 제공한다. [S8]                                                                |
+| 애니메이션이 초기 렌더링에 적용될 때                        | 최종 텍스트 공간을 먼저 확보해 모션이 주변 콘텐츠의 예기치 않은 이동을 만들지 않는다.                                                                          | 가시 요소가 프레임 사이에 위치를 바꾸면 layout shift로 관찰된다. [S9]                                                                  |
+
+## 프로젝트에서 결정할 항목
+
+| 결정                  | 적용 조건                                           | 판단에 사용하는 정보                                        |
+| --------------------- | --------------------------------------------------- | ----------------------------------------------------------- |
+| 모션의 정보 목적      | 모션을 적용할 때마다                                | Content hierarchy, User journey, Brand expression           |
+| 분절 단위             | 순차 등장 효과가 필요할 때                          | Locale, Copy structure, Typography, Accessibility           |
+| 유발 시점과 재생 정책 | 초기 등장, viewport 진입 또는 상태 변화에 반응할 때 | Product behavior, Navigation model, Replay frequency        |
+| 순서와 시차           | 여러 단위를 순차 표시할 때                          | Reading order, Motion foundation, Content length            |
+| 이동 방향과 거리      | 위치 이동이 목적에 부합할 때                        | Writing direction, Layout direction, Motion foundation      |
+| duration과 easing     | 모션을 사용할 때                                    | Motion foundation, Content length, Interaction frequency    |
+| interruption 결과     | 콘텐츠나 상태가 모션 중 바뀔 수 있을 때             | State machine, Live updates, User intent                    |
+| 감소된 모션 대체      | 비필수 모션이 있을 때                               | Accessibility preference, Static hierarchy, Color           |
+| 접근성 트리 표현 방식 | 시각 분절이 DOM 구조를 늘릴 때                      | Semantic element, Screen reader behavior, Copy requirements |
+
+## 토큰 결정 지도
+
+```yaml
+text:
+  color: color
+  typography: typography
+
+item-motion:
+  transition-duration: motion
+  transition-timing-function: motion
+  transform-distance: motion
+  opacity: motion
+
+sequence:
+  stagger-interval: motion
+  start-delay: motion
+
+layout:
+  inline-gap: spacing
+  block-gap: spacing
+
+reduced-motion:
+  transition-duration: motion
+  opacity: motion
+```
+
+`inline-gap`과 `block-gap`은 원문에 없는 간격을 임의로 추가하기 위한 값이 아니다. 프로젝트 typography와 원문의 공백을 보존하면서 별도 레이아웃 간격이 필요한 경우에만 사용한다.
+
+## 엔지니어링 지식
+
+### 의미와 동작
+
+애니메이션 전후의 콘텐츠는 동일한 실제 텍스트여야 한다. heading, paragraph, label 등 원래 요소의 의미를 컨테이너 편의를 위해 일반 요소로 바꾸지 않는다. 시각 분절용 노드와 보조 기술용 원문을 별도로 두는 전략을 선택한다면 한 표현만 접근성 트리에 노출해 중복 발표를 막고, 검색·선택·복사 결과도 원문과 일치시키는지 확인한다.
+
+글자 분절은 grapheme cluster를 기준으로 한다. 단어 분절은 공백이 없는 언어와 구두점 규칙을 고려한다. 시각적 줄은 작성자가 넣은 줄바꿈과 브라우저가 폭에 따라 만든 줄바꿈을 구분하며, 반응형 reflow 후 오래된 줄 그룹을 유지하지 않는다.
+
+### 레이아웃
+
+모든 항목의 최종 geometry를 정상 문서 흐름에서 먼저 결정한 뒤 표현만 애니메이션한다. 항목을 inline wrapper로 나눌 때 기존 줄바꿈 기회와 공백을 보존한다. 글자나 단어 wrapper가 `inline-block`처럼 동작하면 kerning, ligature, 줄바꿈과 양쪽 맞춤 결과가 달라질 수 있으므로 지원 typography와 locale에서 확인한다.
+
+viewport, font load, zoom, writing mode와 사용자 지정 글자·단어·줄 간격이 바뀌어도 텍스트가 잘리거나 겹치지 않아야 한다. WCAG의 text spacing 기준은 특정 값을 강제하는 것이 아니라 사용자가 간격을 덮어써도 정보 손실이 없어야 한다는 요구다. [S4]
+
+### 접근성
+
+화면 낭독기가 각 글자를 끊어 읽도록 시각 wrapper를 의미 단위로 노출하지 않는다. 원래 문장의 언어 속성, 강조, 링크 같은 의미 있는 하위 구조를 보존한다. 숨김 초기 상태가 접근성 트리에서도 원문을 제거하는 구현이라면, 모션이 실행되지 않거나 JavaScript가 실패했을 때 텍스트가 영구히 사라지지 않도록 정적 기본 상태를 우선한다.
+
+감소된 모션에서는 stagger delay를 단순히 줄이는 것보다 읽을 수 있는 최종 텍스트를 즉시 보여주는 것이 우선이다. 텍스트 등장 자체가 새로운 상태나 오류를 알리는 경우에는 애니메이션과 별개로 적절한 상태 전달 패턴을 적용하며, 모든 프레임을 live region에 발표하지 않는다.
+
+### 렌더링과 브라우저
+
+콘텐츠 변경마다 새 애니메이션을 누적하지 않는다. 이전 실행을 취소하고 최신 DOM의 현재 시각 상태에서 새 최종 상태로 이어지게 하거나 즉시 완료한다. 취소된 애니메이션의 완료 promise와 콜백이 새 원문을 수정하지 않도록 실행 식별자나 상태 소유권을 분명히 한다. [S8]
+
+분절 결과는 locale, 텍스트, writing direction이 바뀌면 무효화한다. 줄 단위 측정이 필요한 구현은 font load와 container resize 후 재계산 비용을 고려하며, 측정과 쓰기를 반복해 프레임마다 layout을 강제하지 않는다. 서버 렌더링과 hydration을 사용하는 프로젝트에서는 초기 원문 DOM과 클라이언트 분절 DOM의 불일치도 별도로 다룬다.
+
+## 검증 관점
+
+- 애니메이션, JavaScript, 스타일시트를 각각 끈 상태에서도 완전한 원문과 의미 구조가 남는가
+- 화면 낭독기가 문장을 글자별로 끊거나 같은 원문을 두 번 발표하지 않는가
+- emoji, 결합 문자, 비라틴 문자와 공백 없는 언어가 글자·단어 분절에서 깨지지 않는가
+- 텍스트 선택, 복사, 페이지 검색 결과가 원문과 일치하는가
+- zoom, font load, 좁은 viewport, writing direction 변경 후 줄 그룹과 읽기 순서가 올바른가
+- 사용자 지정 글자·단어·줄 간격에서 텍스트가 잘리거나 겹치거나 사라지지 않는가
+- 감소된 모션에서 순차 지연 없이 최종 텍스트와 같은 정보가 즉시 보이는가
+- 콘텐츠를 빠르게 교체하거나 컴포넌트를 제거할 때 오래된 애니메이션과 콜백이 남지 않는가
+- 모션 전후에 주변 콘텐츠의 예기치 않은 layout shift가 발생하지 않는가
+
+## 출처
+
+- [S1] [W3C WAI, Technique C22: Using CSS to control visual presentation of text](https://www.w3.org/WAI/WCAG22/Techniques/css/C22.html)
+- [S2] [WCAG 2.2, Success Criterion 1.3.1 Info and Relationships](https://www.w3.org/TR/WCAG22/#info-and-relationships)
+- [S3] [MDN, JavaScript Internationalization: Segmentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Internationalization#segmentation)
+- [S4] [W3C WAI, Understanding SC 1.4.12 Text Spacing](https://www.w3.org/WAI/WCAG22/Understanding/text-spacing)
+- [S5] [MDN, `prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/%40media/prefers-reduced-motion)
+- [S6] [W3C WAI, Understanding SC 2.3.3 Animation from Interactions](https://www.w3.org/WAI/WCAG22/Understanding/animation-from-interactions)
+- [S7] [W3C WAI, Understanding SC 2.2.2 Pause, Stop, Hide](https://www.w3.org/WAI/WCAG22/Understanding/pause-stop-hide)
+- [S8] [MDN, `Animation.cancel()`](https://developer.mozilla.org/en-US/docs/Web/API/Animation/cancel)
+- [S9] [MDN, `LayoutShift`](https://developer.mozilla.org/en-US/docs/Web/API/LayoutShift)
+- [S10] [Carbon Design System, Motion](https://carbondesignsystem.com/elements/motion/overview/)

--- a/packages/ui/src/component/avatar/guide.md
+++ b/packages/ui/src/component/avatar/guide.md
@@ -1,0 +1,109 @@
+---
+name: avatar
+platform: web
+---
+
+# Avatar
+
+## 역할
+
+Avatar는 사람, 팀, 조직, 봇처럼 제품 안에서 식별되는 주체를 시각적으로 나타낸다. 사진이 없거나 불러올 수 없을 때도 같은 주체를 알아볼 수 있는 대체 표현을 유지한다. Avatar 자체는 선택, 메뉴 열기, 온라인 상태 전달을 기본 책임으로 갖지 않으며, 그런 기능이 필요할 때는 해당 의미를 가진 상위 컴포넌트와 결합한다.
+
+## 보장해야 하는 계약
+
+| 조건                                                                 | 규칙                                                                                                                           | 근거                                                                                                                |
+| -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------- |
+| 항상                                                                 | 이미지, 대체 표현, 로딩 결과가 바뀌어도 같은 주체를 나타내며 외곽 크기와 주변 레이아웃을 안정적으로 유지한다.                  | 이미지 공간을 미리 확보하면 로딩 중 레이아웃 이동을 방지할 수 있다. [S4]                                            |
+| 이미지가 주변 텍스트에 없는 정보를 전달할 때                         | 이미지 목적을 간결하게 대신하는 텍스트 대안을 제공한다. 파일명이나 단순히 “이미지”라는 표현을 대안으로 사용하지 않는다.        | 비텍스트 콘텐츠에는 동등한 목적의 텍스트 대안이 필요하며, `alt`는 이미지의 명확하고 간결한 대체여야 한다. [S1] [S2] |
+| 같은 주체 이름이 인접 텍스트나 상위 컨트롤의 이름으로 이미 제공될 때 | 이미지가 정보를 반복할 뿐이라면 장식 이미지로 처리해 중복 발표를 피한다. HTML 이미지에서는 빈 `alt`가 표준적인 처리다.         | 인접 텍스트가 이미 같은 정보를 제공하는 이미지는 빈 `alt`로 보조 기술에서 제외할 수 있다. [S3]                      |
+| 이미지가 없거나 로드에 실패할 때                                     | 대체 표현을 제공하되, 사진에만 있던 의미를 임의로 추론하지 않는다. 대체 표현이 텍스트라면 대상 주체와 일관되게 생성한다.       | Avatar는 사용자나 엔터티의 시각적 표현이며 [S6], 이미지의 텍스트 대안은 실제 목적과 문맥에 따라 정해야 한다. [S1]   |
+| 이미지를 고정된 프레임에 맞출 때                                     | 자르기, 맞춤, 초점 위치 정책을 명시하고 중요한 얼굴이나 표식이 의도치 않게 잘리지 않는지 확인한다.                             | 대체 요소인 이미지의 프레임 내 크기와 위치는 `object-fit`과 `object-position`으로 별도 제어된다. [S5]               |
+| Avatar가 링크나 버튼 안에 들어갈 때                                  | 상호작용 의미, 키보드 동작, 접근 가능한 이름은 링크나 버튼이 소유한다. Avatar의 사진 설명만으로 동작의 이름을 대신하지 않는다. | 컨트롤인 비텍스트 콘텐츠에는 목적을 설명하는 이름이 필요하다. [S1]                                                  |
+
+## 프로젝트에서 결정할 항목
+
+| 결정                           | 적용 조건                                  | 판단에 사용하는 정보                                         |
+| ------------------------------ | ------------------------------------------ | ------------------------------------------------------------ |
+| 주체 종류와 표시 목적          | 항상                                       | Product domain, Content model                                |
+| 이미지가 정보성인지 장식성인지 | 사용 문맥마다                              | 주변 레이블, 접근 가능한 이름, Content guidelines            |
+| 대체 표현의 종류와 생성 규칙   | 이미지가 선택 사항이거나 실패할 수 있을 때 | Locale, Naming rules, Privacy, Icon foundation               |
+| 프레임의 모양과 크기 체계      | 항상                                       | Shape, Spacing, Density, Usage context                       |
+| 이미지 맞춤과 초점 정책        | 원본 비율이 프레임과 다를 때               | Media policy, User-generated content, Cropping behavior      |
+| 이미지 로딩과 교체 정책        | 원격 또는 지연 로딩 이미지를 사용할 때     | Performance budget, Cache policy, Perceived stability        |
+| 테두리와 배경 처리             | 배경과 이미지 경계를 구분해야 할 때        | Color, Border, Contrast                                      |
+| 상태 표시의 결합 방식          | 상태나 배지를 함께 보여 주는 제품만        | Status semantics, Color, Icon, Accessibility                 |
+| 상호작용 래퍼                  | Avatar가 동작을 실행할 때만                | Interaction model, Button or Link contract, Focus foundation |
+
+## 토큰 결정 지도
+
+```yaml
+root:
+  inline-size: spacing
+  block-size: spacing
+  border-radius: radius
+  border-color: color
+  border-width: border
+  background-color: color
+
+image:
+  inline-size: spacing
+  block-size: spacing
+
+fallback:
+  color: color
+  background-color: color
+  typography: typography
+
+focus:
+  outline-color: color
+  outline-width: border
+  outline-offset: spacing
+```
+
+`focus`는 Avatar를 상호작용 요소와 결합하는 경우에만 프로젝트 문서에 반영한다. 상태 표시가 필요하면 별도 상태 컴포넌트의 토큰 지도를 결합하고 Avatar의 기본 anatomy로 강제하지 않는다.
+
+## 엔지니어링 지식
+
+### 의미와 동작
+
+Avatar의 핵심 데이터는 “어떤 주체를 나타내는가”이다. 이미지 URL을 정체성의 유일한 원천으로 삼지 말고, 이미지 실패 후에도 동일한 주체의 대체 표현을 계산할 수 있어야 한다. 대체 문자는 모든 문화권의 이름에서 같은 방식으로 만들 수 없으므로 이름 순서, 공백, 단일 이름, 비라틴 문자에 대한 프로젝트 규칙을 적용한다.
+
+이미지의 `alt`는 컴포넌트 이름으로 고정할 수 없다. 목록에서 이름이 바로 옆에 반복되는 경우와, 사진 자체가 유일한 식별 정보인 경우의 목적이 다르기 때문이다. 상태 표시, 알림 수, 편집 동작은 조건부 결합 기능이며 Avatar가 임의로 발표해서는 안 된다.
+
+### 레이아웃
+
+루트는 이미지가 다운로드되기 전에 최종 공간을 예약한다. 이미지와 fallback은 같은 프레임을 점유해 교체 시 주변 콘텐츠가 이동하지 않게 한다. 이미지 비율은 원본에 맡기지 않고 프로젝트의 맞춤 정책을 적용하되, 사용자 생성 사진의 핵심 부분이 잘릴 수 있다는 점을 검토한다.
+
+목록과 조밀한 레이아웃에서는 Avatar가 의도치 않게 축소되는지 확인한다. 확대, 고대비, 긴 인접 이름에서도 Avatar가 레이블을 밀어내거나 가리지 않아야 한다.
+
+### 접근성
+
+텍스트 대안은 이미지 파일의 묘사가 아니라 해당 문맥에서 이미지가 하는 일을 설명한다. 같은 이름이 인접해 있으면 중복 발표를 피하고, 이미지가 유일한 정보라면 그 목적을 대체한다. fallback 문자가 시각적으로 보인다는 이유만으로 자동으로 충분한 접근 가능한 이름이 되는 것은 아니다.
+
+Avatar를 클릭 가능하게 만들 때는 의미 없는 컨테이너에 이벤트만 붙이지 않는다. 실제 동작에 맞는 링크나 버튼이 포커스, 이름, 비활성 상태와 입력 동작을 제공해야 한다. presence 같은 상태를 색만으로 전달하지 않으며, 상태 기능이 실제로 포함된 경우에는 별도의 텍스트 의미를 제공한다.
+
+### 렌더링과 브라우저
+
+`img`는 intrinsic 크기를 가진 대체 요소이므로 루트와 이미지의 크기 책임을 분리한다. [MDN의 이미지 요소 문서][S2]가 설명하듯 이미지 박스 안의 맞춤과 위치는 별도 속성으로 제어된다. 로드 성공, 오류, 소스 변경이 순서와 다르게 도착할 수 있으므로 현재 소스에 해당하는 결과만 화면 상태에 반영한다.
+
+fallback과 이미지가 잠시 동시에 보이는 플래시를 피하되, fallback을 늦추는 동안 빈 영역을 만들지는 프로젝트의 로딩 정책에 따라 판단한다. 외부 이미지 서비스 사용 시에는 인증, referrer, 캐시, 개인정보 정책도 제품 수준에서 검토한다.
+
+## 검증 관점
+
+- 이미지 다운로드 전, 성공 후, 실패 후에 Avatar 외곽과 주변 레이아웃이 이동하지 않는가
+- 인접한 이름이 있을 때 스크린 리더가 같은 이름을 불필요하게 반복하지 않는가
+- 이미지가 유일한 정보일 때 목적에 맞는 텍스트 대안이 제공되는가
+- 빈 URL, 깨진 URL, 느린 응답, 소스의 빠른 교체에서도 올바른 fallback이 남는가
+- 긴 이름, 단일 이름, 비라틴 문자와 결합 문자를 대체 표현 규칙이 손상하지 않는가
+- 다양한 원본 비율에서 얼굴이나 핵심 표식이 예기치 않게 잘리지 않는가
+- 확대와 사용자 지정 텍스트 간격에서도 인접 레이블이 잘리거나 겹치지 않는가
+- 상호작용 가능한 경우 키보드 포커스, 접근 가능한 이름, 동작 의미가 상위 컨트롤에서 유지되는가
+
+## 출처
+
+- [S1] [WCAG 2.2, Success Criterion 1.1.1 Non-text Content](https://www.w3.org/TR/WCAG22/#non-text-content)
+- [S2] [MDN, `<img>`: Authoring meaningful alternate descriptions](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/img#authoring_meaningful_alternate_descriptions)
+- [S3] [W3C WAI, Decorative Images](https://www.w3.org/WAI/tutorials/images/decorative/)
+- [S4] [web.dev, Optimize Cumulative Layout Shift: Images without dimensions](https://web.dev/articles/optimize-cls#images_without_dimensions)
+- [S5] [MDN, `object-fit`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/object-fit)
+- [S6] [Atlassian Design System, Avatar](https://atlassian.design/components/avatar/)

--- a/packages/ui/src/component/button/guide.md
+++ b/packages/ui/src/component/button/guide.md
@@ -1,0 +1,99 @@
+---
+name: button
+platform: web
+---
+
+# Button
+
+## 역할
+
+Button은 사용자가 제출, 취소, 열기, 삭제처럼 즉시 실행되는 명령을 시작하게 한다. 다른 위치로 이동하는 목적이라면 링크 의미를 사용하고, 버튼처럼 보인다는 이유만으로 탐색을 버튼으로 바꾸지 않는다. HTML의 `button`은 내용으로 이름 붙는 버튼을 나타내며, APG도 버튼과 링크의 기능을 구분한다. [HTML Standard](https://html.spec.whatwg.org/multipage/form-elements.html#the-button-element), [APG Button Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/button/)
+
+## 보장해야 하는 계약
+
+| 조건                                    | 규칙                                                                                                                                                              | 근거                                                                                                                                                                                                                                                             |
+| --------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 항상                                    | 가능한 경우 네이티브 `button` 의미와 플랫폼의 키보드·포커스·비활성 동작을 보존한다. 커스텀 역할을 쓴다면 같은 이름, 역할, 상태, 키보드 실행을 제공한다.           | [HTML Standard](https://html.spec.whatwg.org/multipage/form-elements.html#the-button-element), [WCAG 2.2 4.1.2](https://www.w3.org/TR/WCAG22/#name-role-value)                                                                                                   |
+| 폼 안에 있을 때                         | 제출, 초기화, 일반 명령 중 의도한 동작을 명시한다. `button`의 누락된 `type`은 문맥에 따라 제출 버튼이 될 수 있다.                                                 | [HTML Standard](https://html.spec.whatwg.org/multipage/form-elements.html#the-button-element)                                                                                                                                                                    |
+| 텍스트 또는 아이콘으로 내용을 표현할 때 | 버튼에는 기능을 식별하는 접근 가능한 이름이 있어야 하며, 보이는 텍스트가 있다면 그 텍스트가 접근 가능한 이름에 포함되어야 한다.                                   | [WCAG 2.2 4.1.2](https://www.w3.org/TR/WCAG22/#name-role-value), [WCAG 2.2 2.5.3](https://www.w3.org/TR/WCAG22/#label-in-name)                                                                                                                                   |
+| 키보드로 접근할 때                      | 포커스를 볼 수 있고 명령을 키보드로 실행할 수 있어야 한다. APG의 `Enter`와 `Space` 동작은 널리 쓰이는 권고 패턴이지만 APG 자체는 비규범 자료다.                   | [WCAG 2.2 2.1.1](https://www.w3.org/TR/WCAG22/#keyboard), [WCAG 2.2 2.4.7](https://www.w3.org/TR/WCAG22/#focus-visible), [APG 소개](https://www.w3.org/WAI/ARIA/apg/about/introduction/), [APG Button Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/button/) |
+| 명령을 실행할 수 없을 때                | 시각적 비활성 표현과 실제 실행 가능 상태를 일치시킨다. 네이티브 `disabled`는 상호작용과 폼 제출을 막으며, `aria-disabled`만 사용한다면 실행 차단은 구현 책임이다. | [HTML Standard](https://html.spec.whatwg.org/multipage/form-elements.html#the-button-element), [WAI-ARIA `aria-disabled`](https://www.w3.org/TR/wai-aria/#aria-disabled)                                                                                         |
+| 포인터로 조작할 때                      | 목표 크기 또는 목표 간 간격이 WCAG 2.2의 최소 요구를 만족해야 한다.                                                                                               | [WCAG 2.2 2.5.8](https://www.w3.org/TR/WCAG22/#target-size-minimum)                                                                                                                                                                                              |
+| 사용자 정의 외형을 적용할 때            | 경계, 상태, 포커스처럼 컴포넌트를 식별하는 시각 정보는 배경과 구분되고 색상 하나에만 의존하지 않아야 한다.                                                        | [WCAG 2.2 1.4.11](https://www.w3.org/TR/WCAG22/#non-text-contrast), [WCAG 2.2 1.4.1](https://www.w3.org/TR/WCAG22/#use-of-color)                                                                                                                                 |
+
+## 프로젝트에서 결정할 항목
+
+| 결정                          | 적용 조건                                       | 판단에 사용하는 정보                                        |
+| ----------------------------- | ----------------------------------------------- | ----------------------------------------------------------- |
+| 명령의 강조 수준              | 한 화면에 중요도가 다른 명령이 공존할 때        | 제품의 작업 우선순위, 위험도, Color Foundation              |
+| 제출·초기화·일반 명령 의미    | 폼에 배치할 때                                  | 폼 동작, 데이터 보존 정책                                   |
+| 아이콘과 텍스트 구성          | 공간이 제한되거나 반복 도구 모음에 배치할 때    | 콘텐츠 전략, 아이콘 체계, 현지화, 접근 가능한 이름 정책     |
+| 진행 중 동작과 중복 실행 방지 | 비동기 명령일 때                                | 제품 상태 모델, 재시도 가능성, 응답 시간, Motion Foundation |
+| 토글 상태 지원                | 같은 명령이 지속적인 켜짐/꺼짐 상태를 표현할 때 | 제품 상태 모델, 선택 컨트롤과의 경계                        |
+| 너비, 밀도, 줄바꿈            | 긴 번역이나 유동 컨테이너에 배치할 때           | Typography, Spacing, 레이아웃 Foundation, 지원 로케일       |
+
+## 토큰 결정 지도
+
+```yaml
+root:
+  color: color
+  background-color: color
+  border-color: color
+  border-width: border
+  border-radius: radius
+  min-size: sizing
+  padding-block: spacing
+  padding-inline: spacing
+  typography: typography
+content:
+  gap: spacing
+icon:
+  color: color
+  size: sizing
+focus:
+  outline-color: color
+  outline-width: border
+  outline-offset: spacing
+state:
+  disabled-opacity: opacity
+motion:
+  transition-duration: motion
+  transition-timing-function: motion
+```
+
+## 엔지니어링 지식
+
+### 의미와 동작
+
+명령과 탐색을 먼저 구분한다. 폼에서는 `type`을 제품 의도에 맞게 결정하고, 클릭 핸들러만으로 네이티브 제출 동작을 중복 구현하지 않는다. 지속적인 눌림 상태가 실제로 필요할 때만 toggle button 모델을 선택하며, APG는 상태가 유지되는 토글의 레이블을 바꾸지 않고 `aria-pressed`로 상태를 전달하는 방식을 권고한다. 이 권고는 APG의 비규범 패턴이다. [APG Button Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/button/), [APG 소개](https://www.w3.org/WAI/ARIA/apg/about/introduction/)
+
+### 레이아웃
+
+텍스트 확대와 번역 확장을 수용하고, 아이콘과 레이블이 겹치거나 잘리지 않게 한다. 고정 폭이나 `white-space` 정책은 프로젝트의 실제 컨테이너와 로케일을 근거로 정한다. 버튼 안에는 다른 대화형 요소를 중첩하지 않는다. HTML은 `button`의 자손으로 interactive content와 `tabindex`가 지정된 자손을 허용하지 않는다. [HTML Standard](https://html.spec.whatwg.org/multipage/form-elements.html#the-button-element)
+
+### 접근성
+
+아이콘 전용 버튼은 주변 맥락에 의존하지 않는 이름을 제공한다. 새 문맥을 여는 명령은 실행 뒤 논리적인 포커스 위치를 설계한다. APG가 제시하는 실행 후 포커스 이동은 동작 유형별 권고이며 규범 요구사항 자체는 아니다. [APG Button Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/button/), [APG 소개](https://www.w3.org/WAI/ARIA/apg/about/introduction/)
+
+### 렌더링과 브라우저
+
+브라우저 기본 외형을 제거하면 포커스와 상태 표현을 함께 복원해야 한다. 강제 색상 모드에서는 일부 색과 그림자, 배경 이미지가 사용자 팔레트에 맞게 강제되거나 제거되므로 그림자 하나만으로 경계나 포커스를 표현하지 않는다. [MDN `forced-colors`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/forced-colors)
+
+## 검증 관점
+
+- 폼 안의 일반 명령이 의도치 않게 제출을 발생시키지 않는가
+- 보이는 레이블과 접근 가능한 이름이 기능을 동일하게 설명하는가
+- 키보드로 포커스하고 실행할 수 있으며 포커스 표시가 잘리지 않는가
+- 비활성 또는 진행 중 상태에서 중복 실행이 제품 정책대로 차단되는가
+- 긴 번역, 텍스트 확대, 좁은 컨테이너에서도 내용이 손실되지 않는가
+- 강제 색상 모드에서도 버튼의 경계, 상태, 포커스를 식별할 수 있는가
+
+## 출처
+
+- [HTML Standard: The button element](https://html.spec.whatwg.org/multipage/form-elements.html#the-button-element)
+- [WCAG 2.2](https://www.w3.org/TR/WCAG22/)
+- [WAI-ARIA: `aria-disabled`](https://www.w3.org/TR/wai-aria/#aria-disabled)
+- [APG Button Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/button/)
+- [APG Introduction: APG is not a normative standard](https://www.w3.org/WAI/ARIA/apg/about/introduction/)
+- [MDN: `forced-colors`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/forced-colors)
+- [GOV.UK Design System: Button](https://design-system.service.gov.uk/components/button/)

--- a/packages/ui/src/component/calendar/guide.md
+++ b/packages/ui/src/component/calendar/guide.md
@@ -1,0 +1,131 @@
+---
+name: calendar
+platform: web
+---
+
+# Calendar
+
+## 역할
+
+월 또는 그에 준하는 시간 범위 안에서 날짜의 관계를 보여 주고 날짜를 탐색·선택하게 한다. 날짜 입력 필드, 팝업, 대화상자까지 포함하는 완전한 date picker와는 구분하며, 프로젝트가 이를 조합할 때 각각의 focus·label·validation 계약을 추가한다. 기억하기 쉬운 날짜에는 달력보다 직접 입력이 더 효율적일 수 있고, 날짜 간 관계를 살펴봐야 할 때 달력이 유용하다. [Carbon Date Picker](https://carbondesignsystem.com/components/date-picker/usage/)
+
+## 보장해야 하는 계약
+
+| 조건                                      | 규칙                                                                                                                         | 근거                                                                                                                                                                                                                          |
+| ----------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 상호작용 가능한 날짜 격자를 제공하는 경우 | 격자는 키보드 사용자가 방향키로 날짜 사이를 이동할 수 있는 복합 위젯이어야 하며, 페이지 `Tab` 순서에는 관리된 진입점만 둔다. | [WAI-ARIA Grid Pattern (informative)](https://www.w3.org/WAI/ARIA/apg/patterns/grid/), [APG Date Picker Dialog Example (informative)](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/datepicker-dialog/)      |
+| 날짜에 포커스가 있는 경우                 | 시각 포커스, 프로그램적 포커스, 선택 상태를 서로 구분한다. 포커스 이동만으로 값을 확정하는지는 제품이 명시적으로 결정한다.   | [APG Keyboard Interface (informative)](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/), [`aria-selected` 명세](https://www.w3.org/TR/wai-aria/#aria-selected)                                                  |
+| 선택 가능한 날짜를 제공하는 경우          | 각 날짜는 보조 기술이 일·월·년을 식별할 수 있는 접근 가능한 이름을 가지며, 선택 상태가 프로그램적으로 노출되어야 한다.       | [APG Date Picker Dialog Example (informative)](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/datepicker-dialog/), [WCAG 2.2: Name, Role, Value](https://www.w3.org/TR/WCAG22/#name-role-value)               |
+| 오늘을 표시하는 경우                      | 오늘 표시와 선택 표시는 별개의 상태로 취급하고, 오늘이라는 현재성은 적절한 경우 `aria-current="date"`로 전달한다.            | [`aria-current` 명세](https://www.w3.org/TR/wai-aria/#aria-current)                                                                                                                                                           |
+| 선택 불가 날짜가 있는 경우                | 선택 불가 이유가 데이터 규칙과 일치해야 하며, 보이는 비활성 상태와 실제 실행 가능 여부가 어긋나지 않아야 한다.               | [`aria-disabled` 명세](https://www.w3.org/TR/wai-aria/#aria-disabled), [WCAG 2.2: Name, Role, Value](https://www.w3.org/TR/WCAG22/#name-role-value)                                                                           |
+| 지역화된 달력을 제공하는 경우             | 월명, 요일명, 날짜 순서, 주 시작일과 읽기 방향을 사용자의 locale 및 제품 정책에 맞게 일관되게 처리한다.                      | [`Intl.DateTimeFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat), [Carbon Date Picker 국제화 지침](https://carbondesignsystem.com/components/date-picker/usage/) |
+| 값 범위를 제한하는 경우                   | 최소·최대·업무 규칙은 렌더링, 키보드 탐색, 포인터 선택, 프로그램적 값 변경에 동일하게 적용한다.                              | [WCAG 2.2: Consistent Identification, Error Identification](https://www.w3.org/TR/WCAG22/)                                                                                                                                    |
+
+APG date picker는 WAI-ARIA 명세가 아닌 **informative 예제**이고 프로덕션 코드가 아니다. 모바일·터치와 일부 브라우저·보조 기술 조합의 지원 편차를 전제로 실제 환경에서 검증한다. [APG Date Picker Dialog Example의 사용 전 안내](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/datepicker-dialog/)
+
+## 프로젝트에서 결정할 항목
+
+| 결정                         | 적용 조건                                | 판단에 사용하는 정보                              |
+| ---------------------------- | ---------------------------------------- | ------------------------------------------------- |
+| 선택 모델                    | 날짜를 선택하는 기능이 있을 때           | 단일·범위·다중 선택의 제품 의미, 제출 데이터 모델 |
+| 포커스가 처음 놓일 날짜      | 달력이 열리거나 월이 변경될 때           | 기존 값, 오늘, 허용 범위, 작업 연속성             |
+| 월 밖 날짜 표시와 상호작용   | 격자에 인접 월 날짜가 포함될 때          | 공간 안정성, 월 경계 탐색, 콘텐츠 명료성          |
+| 주 시작 요일                 | 지역화가 필요한 경우                     | locale, 조직 정책, 사용자 설정                    |
+| 주차 수 고정 여부            | 여러 달 사이 레이아웃 안정성이 필요할 때 | 팝업 위치, 페이지 이동량, 콘텐츠 밀도             |
+| 월·연도 이동 수단            | 장거리 날짜 탐색이 필요한 경우           | 사용 날짜 범위, 키보드 비용, 모바일 공간          |
+| 날짜 직접 입력과 달력의 결합 | date picker로 조합할 때                  | 기억 가능한 날짜인지, 검증·형식 안내, 모바일 입력 |
+| 범위 미리보기와 재선택 규칙  | 범위 선택을 지원할 때                    | 예약·분석 도메인 규칙, 취소·수정 흐름             |
+| 시간대와 날짜 정규화 기준    | 서버 값이나 여러 시간대를 다룰 때        | 도메인의 calendar date 의미, 저장 형식, SSR 환경  |
+
+## 토큰 결정 지도
+
+```yaml
+root:
+  color: color
+  background-color: color
+  border-color: color
+  border-width: border
+  border-radius: radius
+  padding: spacing
+
+header:
+  typography: typography
+  gap: spacing
+  margin-block-end: spacing
+
+navigation-control:
+  color: color
+  background-color: color
+  size: sizing
+  border-radius: radius
+
+weekday:
+  color: color
+  typography: typography
+  padding-block: spacing
+
+grid:
+  column-gap: spacing
+  row-gap: spacing
+
+day:
+  color: color
+  background-color: color
+  typography: typography
+  size: sizing
+  border-radius: radius
+
+range:
+  background-color: color
+  boundary-color: color
+
+focus:
+  outline-color: color
+  outline-width: border
+  outline-offset: spacing
+
+motion:
+  duration: motion
+  easing: motion
+```
+
+## 엔지니어링 지식
+
+### 의미와 동작
+
+현재 보고 있는 날짜, 키보드 포커스 날짜, 오늘, 선택 값은 서로 다른 상태다. 월 이동이 선택을 암묵적으로 바꾸지 않게 하고, 날짜 계산은 시간 부분과 DST 변화가 calendar date를 바꾸지 않도록 도메인 기준으로 정규화한다. 월·연도 이동 시 존재하지 않는 날짜를 어떻게 보정할지도 명시한다. JavaScript `Date`는 로컬 시간 또는 UTC 해석에 따라 날짜가 달라질 수 있으므로 직렬화 경계를 별도로 검토한다. [`Date`의 date time string format 주의사항](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#date_time_string_format)
+
+### 레이아웃
+
+요일과 날짜 열의 대응이 확대·번역·RTL에서도 유지되어야 한다. 월마다 행 수가 바뀌는 경우 주변 콘텐츠 이동과 팝업 배치를 확인한다. 날짜 셀의 시각 크기를 고정값으로 일반화하지 말고, 프로젝트의 입력 대상 크기와 밀도 정책에서 결정한다. 좁은 화면에서도 날짜 이름, 선택 범위, 포커스 표시가 잘리거나 겹치지 않아야 한다. [WCAG 2.2 Reflow](https://www.w3.org/WAI/WCAG22/#reflow)
+
+### 접근성
+
+APG의 informative date picker 예제는 화살표로 일 단위, `Home`·`End`로 주 경계, `Page Up`·`Page Down`으로 월 이동을 제안한다. 이를 채택한다면 시각·프로그램적 포커스를 함께 이동하고, 월 제목 변경을 보조 기술이 인지할 수 있게 한다. 키 명령을 변경하거나 일부만 지원할 경우 플랫폼 관례와 충돌하지 않는지 검증한다. [APG Date Picker Dialog Example (informative)](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/datepicker-dialog/)
+
+범위 선택에서는 시작, 끝, 범위 내부, 포커스, 오늘을 색상 하나로만 구분하지 않는다. 포인터로 선택할 수 있는 모든 날짜는 키보드로도 도달하고 실행할 수 있어야 한다. [WCAG 2.2 Keyboard와 Use of Color](https://www.w3.org/TR/WCAG22/)
+
+### 렌더링과 브라우저
+
+월 이름과 요일 이름은 직접 번역 테이블을 조합하기보다 지원 locale을 명시한 국제화 API에서 생성한다. 서버와 클라이언트의 시간대·locale이 다르면 hydration 시 오늘과 월 격자가 달라질 수 있으므로 동일한 기준 데이터를 전달한다. 팝업이나 dialog 안에 배치될 때는 calendar 자체가 아닌 상위 컴포넌트가 focus containment, dismissal, positioning을 책임지도록 경계를 유지한다.
+
+## 검증 관점
+
+- 오늘, 포커스, 선택, 비활성 상태를 각각 구분할 수 있는가
+- 방향키 탐색이 주·월·연도 경계에서 날짜를 잃지 않는가
+- 월 이동이 선택 값을 의도치 않게 변경하지 않는가
+- locale 변경 시 월명, 요일명, 주 시작일과 읽기 방향이 함께 바뀌는가
+- 범위의 시작과 끝을 역순으로 선택할 때 규칙이 예측 가능한가
+- 최소·최대 날짜 규칙이 모든 입력 방식에서 동일하게 적용되는가
+- 확대, 좁은 화면, 긴 번역에서 7개 열의 의미가 유지되는가
+- 서버와 클라이언트의 시간대가 달라도 같은 calendar date가 표시되는가
+
+## 출처
+
+- [WAI-ARIA 1.2](https://www.w3.org/TR/wai-aria/)
+- [WAI-ARIA APG Grid Pattern (informative)](https://www.w3.org/WAI/ARIA/apg/patterns/grid/)
+- [APG Date Picker Dialog Example (informative)](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/datepicker-dialog/)
+- [APG Keyboard Interface (informative)](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/)
+- [WCAG 2.2](https://www.w3.org/TR/WCAG22/)
+- [MDN `Intl.DateTimeFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat)
+- [Carbon Date Picker](https://carbondesignsystem.com/components/date-picker/usage/)

--- a/packages/ui/src/component/checkbox/guide.md
+++ b/packages/ui/src/component/checkbox/guide.md
@@ -1,0 +1,104 @@
+---
+name: checkbox
+platform: web
+---
+
+# Checkbox
+
+## 역할
+
+Checkbox는 서로 독립적으로 선택하거나 해제할 수 있는 이진 선택을 표현한다. 여러 하위 선택의 집계 상태를 보여 줄 때만 혼합 상태를 사용할 수 있다. HTML의 checkbox는 checkedness를 나타내는 두 상태 컨트롤이며, indeterminate는 checkedness와 독립적인 표시·접근성 상태다. [HTML Standard](<https://html.spec.whatwg.org/multipage/input.html#checkbox-state-(type=checkbox)>)
+
+## 보장해야 하는 계약
+
+| 조건                           | 규칙                                                                                                                                                       | 근거                                                                                                                                                                                                            |
+| ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 항상                           | 가능한 경우 네이티브 `input type="checkbox"`의 폼 값, 키보드, 포커스, 이벤트, 접근성 의미를 보존한다.                                                      | [HTML Standard](<https://html.spec.whatwg.org/multipage/input.html#checkbox-state-(type=checkbox)>), [ARIA in HTML](https://www.w3.org/TR/html-aria/)                                                           |
+| 각 checkbox                    | 기능을 설명하는 접근 가능한 이름을 제공하고, 보이는 레이블이 있다면 컨트롤과 프로그램적으로 연결한다.                                                      | [HTML Standard: label](https://html.spec.whatwg.org/multipage/forms.html#the-label-element), [WCAG 2.2 4.1.2](https://www.w3.org/TR/WCAG22/#name-role-value)                                                    |
+| 사용자가 상태를 변경할 때      | 시각적 표시, 접근성 상태, 폼 값, 애플리케이션 상태가 같은 checked 상태를 반영해야 한다.                                                                    | [HTML Standard](<https://html.spec.whatwg.org/multipage/input.html#checkbox-state-(type=checkbox)>), [WCAG 2.2 4.1.2](https://www.w3.org/TR/WCAG22/#name-role-value)                                            |
+| 일부 하위 항목만 선택되었을 때 | 혼합 상태는 부분 선택을 표현해야 하며 일반적인 제3의 제출 값으로 취급하지 않는다. 네이티브 `indeterminate`는 checkedness와 독립적이다.                     | [HTML Standard: indeterminate](https://html.spec.whatwg.org/multipage/input.html#dom-input-indeterminate)                                                                                                       |
+| 커스텀 checkbox를 구현할 때    | `checkbox` 역할, 접근 가능한 이름, `aria-checked`의 `true`·`false`·필요 시 `mixed`, `Space` 조작을 구현한다. APG의 키보드 패턴은 유용하지만 비규범 자료다. | [WAI-ARIA checkbox role](https://www.w3.org/TR/wai-aria/#checkbox), [APG Checkbox Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/checkbox/), [APG 소개](https://www.w3.org/WAI/ARIA/apg/about/introduction/) |
+| 필수 동의일 때                 | 미선택 상태를 폼의 누락 값으로 처리하고, 요구 조건을 레이블이나 지시문으로 전달한다.                                                                       | [HTML Standard](<https://html.spec.whatwg.org/multipage/input.html#checkbox-state-(type=checkbox)>), [WCAG 2.2 3.3.2](https://www.w3.org/TR/WCAG22/#labels-or-instructions)                                     |
+| 비활성일 때                    | 실제 조작과 제출 가능 여부가 시각적 상태와 일치해야 한다.                                                                                                  | [HTML Standard: disabled](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fe-disabled), [WCAG 2.2 4.1.2](https://www.w3.org/TR/WCAG22/#name-role-value)                            |
+| 포인터로 조작할 때             | 입력과 연결된 레이블을 함께 사용할 수 있게 하고 목표 크기 또는 간격의 최소 요구를 만족한다.                                                                | [HTML Standard: label](https://html.spec.whatwg.org/multipage/forms.html#the-label-element), [WCAG 2.2 2.5.8](https://www.w3.org/TR/WCAG22/#target-size-minimum)                                                |
+
+## 프로젝트에서 결정할 항목
+
+| 결정                           | 적용 조건                           | 판단에 사용하는 정보                           |
+| ------------------------------ | ----------------------------------- | ---------------------------------------------- |
+| 단독 선택과 그룹 경계          | 여러 checkbox가 같은 질문에 답할 때 | 제품 정보 구조, 폼 모델, 콘텐츠 전략           |
+| 혼합 상태의 계산과 활성화 결과 | 부모·자식 선택 관계가 있을 때       | 도메인 선택 규칙, 상태 전이 정책               |
+| 도움말과 오류 위치             | 요구 조건이나 검증이 있을 때        | 폼 검증 정책, 콘텐츠 Foundation                |
+| 선택 표시 방식                 | 사용자 정의 외형을 적용할 때        | Color, Icon, Border Foundation, 강제 색상 지원 |
+| 읽기 전용과 비활성의 구분      | 값을 보여 주되 변경 권한이 없을 때  | 권한 모델, 제출 정책, 제품 피드백 방식         |
+| 그룹 배열과 레이블 줄바꿈      | 항목이 많거나 문구가 길 때          | 레이아웃, Typography, Spacing, 지원 로케일     |
+
+## 토큰 결정 지도
+
+```yaml
+control:
+  color: color
+  background-color: color
+  border-color: color
+  border-width: border
+  border-radius: radius
+  size: sizing
+label:
+  color: color
+  typography: typography
+layout:
+  control-label-gap: spacing
+  group-gap: spacing
+indicator:
+  color: color
+  size: sizing
+focus:
+  outline-color: color
+  outline-width: border
+  outline-offset: spacing
+state:
+  disabled-opacity: opacity
+motion:
+  transition-duration: motion
+  transition-timing-function: motion
+```
+
+## 엔지니어링 지식
+
+### 의미와 동작
+
+Checkbox는 각 항목을 독립적으로 선택할 수 있을 때 사용한다. 하나만 선택 가능한 집합은 radio 계열의 책임이다. 혼합 상태는 하위 선택의 집계라는 실제 관계가 있을 때만 노출하며, 사용자가 부모를 활성화했을 때 전체 선택·전체 해제·이전 부분 상태 복원 중 무엇이 일어나는지는 도메인 규칙으로 명시한다. APG는 여러 가능한 혼합 상태 전이를 설명하지만 이는 비규범 권고다. [APG Checkbox Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/checkbox/), [APG 소개](https://www.w3.org/WAI/ARIA/apg/about/introduction/)
+
+### 레이아웃
+
+레이블 전체가 읽히고 자연스럽게 줄바꿈되어야 한다. 항목이 그룹이면 질문을 설명하는 그룹 레이블을 제공하고, 시각적 근접성과 프로그램적 그룹 관계를 함께 설계한다. Carbon도 checkbox 레이블을 생략하거나 말줄임하지 않고 긴 문구를 줄바꿈하도록 권고한다. 이는 성숙한 디자인 시스템의 사용 지침이지 웹 표준 요구 자체는 아니다. [Carbon Checkbox](https://carbondesignsystem.com/components/checkbox/usage/)
+
+### 접근성
+
+네이티브 입력을 시각적으로 숨길 때도 포커스 가능성과 접근성 트리 노출을 유지한다. checked, unchecked, mixed를 색상만으로 구분하지 않고 형태나 표시를 함께 사용한다. 상태를 바꾸는 실제 focus target에 focus indicator가 나타나야 한다. [WCAG 2.2 1.4.1](https://www.w3.org/TR/WCAG22/#use-of-color), [WCAG 2.2 2.4.7](https://www.w3.org/TR/WCAG22/#focus-visible)
+
+### 렌더링과 브라우저
+
+네이티브 외형을 유지하며 테마 색만 조정할지, 외형을 완전히 대체할지 프로젝트에서 정한다. `accent-color`는 일부 사용자 인터페이스 컨트롤의 accent를 바꾸지만 모든 컨트롤과 상태에 적용되지는 않는다. 강제 색상 모드는 색, 그림자, 배경 이미지를 바꾸거나 제거할 수 있으므로 URL 이미지나 그림자에만 선택 표시를 의존하지 않는다. [MDN `accent-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/accent-color), [MDN `forced-colors`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/forced-colors)
+
+## 검증 관점
+
+- 레이블을 누르면 의도한 checkbox가 활성화되는가
+- `Space`로 상태가 바뀌고 포커스가 계속 보이는가
+- checked, unchecked, indeterminate가 시각·접근성·애플리케이션 상태에서 일치하는가
+- 폼 초기화와 제출에서 네이티브 값 계약이 유지되는가
+- 긴 레이블이 잘리지 않고 컨트롤과의 관계를 잃지 않는가
+- 강제 색상 모드에서도 선택과 혼합 상태를 구분할 수 있는가
+
+## 출처
+
+- [HTML Standard: Checkbox state](<https://html.spec.whatwg.org/multipage/input.html#checkbox-state-(type=checkbox)>)
+- [HTML Standard: The label element](https://html.spec.whatwg.org/multipage/forms.html#the-label-element)
+- [ARIA in HTML](https://www.w3.org/TR/html-aria/)
+- [WAI-ARIA: checkbox role](https://www.w3.org/TR/wai-aria/#checkbox)
+- [WCAG 2.2](https://www.w3.org/TR/WCAG22/)
+- [APG Checkbox Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/checkbox/)
+- [APG Introduction](https://www.w3.org/WAI/ARIA/apg/about/introduction/)
+- [Carbon Design System: Checkbox](https://carbondesignsystem.com/components/checkbox/usage/)
+- [MDN: `accent-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/accent-color)
+- [MDN: `forced-colors`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/forced-colors)

--- a/packages/ui/src/component/chip/guide.md
+++ b/packages/ui/src/component/chip/guide.md
@@ -1,0 +1,106 @@
+---
+name: chip
+platform: web
+---
+
+# Chip
+
+## 역할
+
+Chip은 짧은 텍스트를 압축된 형태로 보여 주는 시각 패턴이다. 이름 자체에는 표준 웹 의미가 없으므로, 정적 분류 표시인지, 선택 상태인지, 제거 명령인지, 다른 명령인지 먼저 정한 다음 그 기능에 맞는 HTML 의미를 사용한다. Carbon의 성숙한 tag 지침도 read-only, dismissible, selectable, operational 책임을 분리하며 한 tag에 여러 기능을 넣지 않도록 권고한다. [Carbon Tag](https://carbondesignsystem.com/components/tag/usage/)
+
+## 보장해야 하는 계약
+
+| 조건                         | 규칙                                                                                                                                                              | 근거                                                                                                                                                                                                                                           |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 항상                         | chip이라는 외형이 아니라 실제 기능에 따라 정적 텍스트, 버튼, 링크, 선택 컨트롤 중 의미를 결정한다.                                                                | [WCAG 2.2 4.1.2](https://www.w3.org/TR/WCAG22/#name-role-value), [Carbon Tag](https://carbondesignsystem.com/components/tag/usage/)                                                                                                            |
+| 정적 분류나 상태를 표시할 때 | 포커스와 버튼 역할을 부여하지 않고 텍스트 의미로 노출한다. 색만으로 범주나 상태를 구분하지 않는다.                                                                | [WCAG 2.2 1.4.1](https://www.w3.org/TR/WCAG22/#use-of-color), [WCAG 2.2 4.1.2](https://www.w3.org/TR/WCAG22/#name-role-value)                                                                                                                  |
+| 명령을 실행할 때             | 네이티브 버튼 의미와 접근 가능한 이름을 사용하며 `Enter`와 `Space`로 실행 가능하게 한다. APG 키보드 모델은 비규범 권고다.                                         | [HTML Standard: button](https://html.spec.whatwg.org/multipage/form-elements.html#the-button-element), [APG Button Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/button/), [APG 소개](https://www.w3.org/WAI/ARIA/apg/about/introduction/) |
+| 다른 위치로 이동할 때        | 링크 의미와 목적을 제공한다. 버튼 외형을 탐색 의미의 대체물로 사용하지 않는다.                                                                                    | [HTML Standard: links](https://html.spec.whatwg.org/multipage/links.html#links-created-by-a-and-area-elements), [WCAG 2.2 2.4.4](https://www.w3.org/TR/WCAG22/#link-purpose-in-context)                                                        |
+| 선택 상태를 토글할 때        | 선택 모델을 checkbox 또는 toggle button 중 하나로 명확히 정하고, 상태를 프로그램적으로 전달한다. 외형만 바꾸어 선택을 표현하지 않는다.                            | [WAI-ARIA checkbox role](https://www.w3.org/TR/wai-aria/#checkbox), [WAI-ARIA `aria-pressed`](https://www.w3.org/TR/wai-aria/#aria-pressed), [WCAG 2.2 4.1.2](https://www.w3.org/TR/WCAG22/#name-role-value)                                   |
+| 제거할 수 있을 때            | 제거 target에는 무엇을 제거하는지 포함한 접근 가능한 이름이 있고, chip 전체에 별도 기능이 있다면 중첩된 대화형 요소를 만들지 않는다.                              | [WCAG 2.2 2.4.6](https://www.w3.org/TR/WCAG22/#headings-and-labels), [HTML Standard: button content model](https://html.spec.whatwg.org/multipage/form-elements.html#the-button-element)                                                       |
+| 포인터로 조작할 때           | 각 독립 target이 최소 목표 크기 또는 간격 요구를 충족한다.                                                                                                        | [WCAG 2.2 2.5.8](https://www.w3.org/TR/WCAG22/#target-size-minimum)                                                                                                                                                                            |
+| 텍스트를 잘라 표시할 때      | 전체 이름을 포인터뿐 아니라 키보드와 보조 기술 사용자도 얻을 수 있어야 한다. hover에만 의존하는 추가 콘텐츠는 dismissible, hoverable, persistent 조건을 고려한다. | [WCAG 2.2 1.4.13](https://www.w3.org/TR/WCAG22/#content-on-hover-or-focus), [WCAG 2.2 4.1.2](https://www.w3.org/TR/WCAG22/#name-role-value)                                                                                                    |
+
+## 프로젝트에서 결정할 항목
+
+| 결정                           | 적용 조건                                  | 판단에 사용하는 정보                                |
+| ------------------------------ | ------------------------------------------ | --------------------------------------------------- |
+| 의미 모델                      | 모든 chip 사용처                           | 제품 기능, 정보 구조, 폼·탐색·명령 경계             |
+| 선택 상태 모델                 | 선택 가능한 chip일 때                      | 단일·복수 선택 규칙, 제출 모델, 상태 지속성         |
+| 제거 후 포커스 위치와 되돌리기 | dismissible chip일 때                      | 목록 순서, undo 정책, 사용자 피드백                 |
+| 아이콘의 정보성                | 아이콘을 포함할 때                         | Icon Foundation, 콘텐츠 전략, 중복 정보 여부        |
+| overflow와 wrapping            | 제목이 길거나 chip이 많을 때               | Typography, 레이아웃, 현지화, 전체 텍스트 제공 방식 |
+| 그룹 탐색 방식                 | 많은 선택 chip을 하나의 widget처럼 다룰 때 | 키보드 모델, 폼 의미, 보조 기술 테스트 결과         |
+| 시각적 강조와 선택 구분        | 상호작용 또는 상태가 있을 때               | Color, Border, Elevation Foundation, 대비 정책      |
+
+## 토큰 결정 지도
+
+```yaml
+root:
+  color: color
+  background-color: color
+  border-color: color
+  border-width: border
+  border-radius: radius
+  min-size: sizing
+  padding-block: spacing
+  padding-inline: spacing
+  typography: typography
+content:
+  gap: spacing
+icon:
+  color: color
+  size: sizing
+group:
+  gap: spacing
+focus:
+  outline-color: color
+  outline-width: border
+  outline-offset: spacing
+state:
+  disabled-opacity: opacity
+motion:
+  transition-duration: motion
+  transition-timing-function: motion
+```
+
+## 엔지니어링 지식
+
+### 의미와 동작
+
+단일 컴포넌트 API가 모든 의미를 암묵적으로 선택하게 하지 않는다. 정적 chip은 일반 콘텐츠이고, 제거 chip은 제거 버튼이며, 탐색 chip은 링크다. 선택 chip은 제출 가능한 독립 선택이면 checkbox가 자연스럽고, 같은 명령의 지속적인 눌림 상태라면 toggle button이 맞을 수 있다. APG의 toggle button 패턴은 선택 가능한 구현 지침이며 비규범이다. [APG Button Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/button/), [APG 소개](https://www.w3.org/WAI/ARIA/apg/about/introduction/)
+
+### 레이아웃
+
+짧은 레이블을 기본으로 하되 사용자 생성 문자열과 번역 확장을 고려한다. chip 그룹은 컨테이너에서 자연스럽게 줄바꿈할 수 있어야 하며, DOM 순서와 읽기 순서를 유지한다. 말줄임이 필요하면 전체 문자열을 모든 입력 방식에서 사용할 수 있게 한다. Carbon의 tag 분류와 overflow 방식은 참고 사례이며 프로젝트의 콘텐츠·접근성 정책을 대체하지 않는다. [Carbon Tag](https://carbondesignsystem.com/components/tag/usage/)
+
+### 접근성
+
+읽기 전용 chip을 불필요하게 tab 순서에 넣지 않는다. 아이콘 전용 제거 버튼은 대상 이름을 포함한다. 선택됨, 비활성, 포커스는 색 변화 하나가 아니라 프로그램적 상태와 형태·경계 같은 시각 단서를 함께 사용한다. [WCAG 2.2 1.4.1](https://www.w3.org/TR/WCAG22/#use-of-color), [WCAG 2.2 2.4.7](https://www.w3.org/TR/WCAG22/#focus-visible), [WCAG 2.2 4.1.2](https://www.w3.org/TR/WCAG22/#name-role-value)
+
+### 렌더링과 브라우저
+
+chip 내부에 버튼 안의 버튼 같은 중첩 대화형 구조를 만들지 않는다. 제거 target과 chip 본체가 각각 동작해야 한다면 형제 컨트롤과 공통 시각 컨테이너로 모델링한다. 강제 색상 모드에서 배경색과 그림자가 제거될 수 있으므로 선택·경계·포커스가 유지되는지 확인한다. [HTML Standard: button content model](https://html.spec.whatwg.org/multipage/form-elements.html#the-button-element), [MDN `forced-colors`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/forced-colors)
+
+## 검증 관점
+
+- 각 chip이 정적 정보, 선택, 제거, 명령, 탐색 중 하나의 분명한 책임을 갖는가
+- 읽기 전용 chip이 불필요하게 포커스되지 않는가
+- 선택 chip의 시각 상태와 프로그램적 상태가 일치하는가
+- 제거 버튼의 이름이 제거 대상까지 설명하고 제거 후 포커스가 유효한 위치에 남는가
+- 긴 사용자 생성 문자열과 번역이 전체 정보 접근을 막지 않는가
+- 여러 줄로 배치되어도 DOM 순서와 읽기 순서가 일치하는가
+- 강제 색상 모드에서 포커스와 선택 상태를 구분할 수 있는가
+
+## 출처
+
+- [HTML Standard: The button element](https://html.spec.whatwg.org/multipage/form-elements.html#the-button-element)
+- [HTML Standard: Links](https://html.spec.whatwg.org/multipage/links.html#links-created-by-a-and-area-elements)
+- [WAI-ARIA: checkbox role](https://www.w3.org/TR/wai-aria/#checkbox)
+- [WAI-ARIA: `aria-pressed`](https://www.w3.org/TR/wai-aria/#aria-pressed)
+- [WCAG 2.2](https://www.w3.org/TR/WCAG22/)
+- [APG Button Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/button/)
+- [APG Introduction](https://www.w3.org/WAI/ARIA/apg/about/introduction/)
+- [Carbon Design System: Tag](https://carbondesignsystem.com/components/tag/usage/)
+- [MDN: `forced-colors`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/forced-colors)

--- a/packages/ui/src/component/dialog/guide.md
+++ b/packages/ui/src/component/dialog/guide.md
@@ -1,0 +1,134 @@
+---
+name: dialog
+platform: web
+---
+
+# Dialog
+
+## 역할
+
+현재 작업 위에 제한된 범위의 정보나 결정을 제시하고, 사용자가 이를 완료하거나 명시적으로 닫은 뒤 원래 흐름으로 돌아가게 한다. 이 문서는 배경과의 상호작용을 막는 modal dialog를 중심으로 하며, non-modal window나 즉시 확인이 필요한 alert dialog는 별도의 의미와 동작 계약을 가진다.
+
+## 보장해야 하는 계약
+
+| 조건                                | 규칙                                                                                                                          | 근거                                                                                                                                                                                                                                |
+| ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 모달로 열리는 경우                  | dialog 컨테이너에 모달 의미를 제공하고, 배경 콘텐츠는 시각적으로만 가리는 것이 아니라 사용자 상호작용에서도 비활성화한다.     | [`dialog` role 명세](https://www.w3.org/TR/wai-aria/#dialog), [`aria-modal` 명세](https://www.w3.org/TR/wai-aria/#aria-modal), [`showModal()` 동작](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement/showModal)   |
+| 항상                                | dialog는 보이는 제목을 참조하거나 별도의 접근 가능한 이름을 가져야 한다.                                                      | [`dialog` role의 accessible name 요구](https://www.w3.org/TR/wai-aria/#dialog), [APG Dialog Pattern (informative)](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/)                                                          |
+| 열릴 때                             | 초기 포커스는 dialog 내부의 작업과 콘텐츠 구조에 맞는 요소로 이동해야 하며, 단순히 DOM의 첫 컨트롤로 고정하지 않는다.         | [APG Dialog Pattern의 initial focus 지침 (informative)](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/), [MDN `<dialog>` 접근성](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dialog#accessibility) |
+| 모달이 열린 동안                    | `Tab`과 `Shift+Tab`이 배경으로 빠져나가지 않으며, 포인터와 보조 기술 사용자도 배경을 조작할 수 없어야 한다.                   | [APG Dialog Pattern (informative)](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/), [`showModal()`의 inert 동작](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement/showModal)                              |
+| 닫힐 때                             | 일반적으로 포커스를 dialog를 연 요소 또는 작업 흐름상 다음의 합리적 요소로 복원한다.                                          | [APG Dialog Pattern의 focus return 지침 (informative)](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/)                                                                                                                      |
+| 사용자가 닫을 수 있는 dialog인 경우 | 키보드로 실행 가능한 명시적 닫기 수단을 제공하고, modal dialog의 `Escape` 동작을 유지한다.                                    | [MDN `<dialog>` 접근성](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dialog#accessibility), [APG Dialog Pattern (informative)](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/)                      |
+| 설명이 복잡한 경우                  | 여러 문단·목록·표 전체를 하나의 `aria-describedby`로 연결하지 않고, 구조를 탐색할 수 있게 초기 포커스와 설명 관계를 결정한다. | [APG Dialog Pattern 설명 연결 지침 (informative)](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/)                                                                                                                           |
+
+APG dialog pattern과 예제는 **informative 작성 지침**이며 브라우저·보조 기술 지원을 보증하는 프로덕션 구현이 아니다. ARIA로 직접 구현하는 경우 대상 환경에서 focus containment, 이름 계산, 배경 비활성화를 함께 검증한다. [APG Modal Dialog Example 안내](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/dialog/)
+
+## 프로젝트에서 결정할 항목
+
+| 결정                          | 적용 조건                                    | 판단에 사용하는 정보                                   |
+| ----------------------------- | -------------------------------------------- | ------------------------------------------------------ |
+| modal 또는 non-modal          | 새 표면이 기존 작업을 차단할지 결정할 때     | 작업 의존성, 긴급도, 병렬 작업 필요성                  |
+| 초기 포커스 대상              | dialog를 열 때                               | 파괴적 작업 여부, 읽어야 할 구조, 스크롤 위치          |
+| 닫기 정책                     | backdrop, `Escape`, 명시적 버튼이 있을 때    | 데이터 손실 위험, 필수 결정 여부, 플랫폼 관례          |
+| 제목과 설명 구성              | 콘텐츠 복잡도가 달라질 때                    | 정보 구조, 보조 기술 발표 길이, 콘텐츠 지침            |
+| action 배치와 기본 동작       | 확인·취소·보조 동작이 있을 때                | Product behavior, 로케일 읽기 방향, 위험도             |
+| 크기와 내부 스크롤            | 콘텐츠가 viewport를 넘을 수 있을 때          | 콘텐츠 유형, 반응형 Foundation, 키보드 가시성          |
+| 중첩 허용 여부                | dialog에서 다시 dialog를 열 가능성이 있을 때 | 작업 모델, focus 복원 스택, 모바일 제약                |
+| 비동기 완료 중 닫기 가능 여부 | 제출·저장 작업이 있을 때                     | 취소 가능성, 중복 실행 방지, 오류 복구                 |
+| 열림·닫힘 모션                | 전환을 제공할 때                             | Motion Foundation, reduced-motion 정책, top-layer 동작 |
+
+## 토큰 결정 지도
+
+```yaml
+overlay:
+  background-color: color
+  opacity: color
+
+surface:
+  color: color
+  background-color: color
+  border-color: color
+  border-width: border
+  border-radius: radius
+  box-shadow: elevation
+  padding: spacing
+  max-inline-size: sizing
+  max-block-size: sizing
+
+header:
+  gap: spacing
+  margin-block-end: spacing
+
+title:
+  color: color
+  typography: typography
+
+description:
+  color: color
+  typography: typography
+
+body:
+  color: color
+  typography: typography
+  gap: spacing
+
+footer:
+  gap: spacing
+  margin-block-start: spacing
+
+close-control:
+  color: color
+  size: sizing
+  inset: spacing
+
+focus:
+  outline-color: color
+  outline-width: border
+  outline-offset: spacing
+
+motion:
+  duration: motion
+  easing: motion
+```
+
+## 엔지니어링 지식
+
+### 의미와 동작
+
+열림 상태, 호출자, 초기 포커스, 닫힌 뒤 복원 위치를 하나의 lifecycle로 설계한다. 작업 완료, 취소, 외부 dismiss는 결과가 다를 수 있으므로 모두 같은 “닫기” 이벤트로 손실시키지 않는다. 네이티브 `<dialog>.showModal()`은 top layer, backdrop, background inertness를 제공하므로 요구사항과 브라우저 지원이 맞으면 우선 검토한다. [`<dialog>` 요소](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dialog), [`showModal()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement/showModal)
+
+### 레이아웃
+
+dialog 표면은 작은 viewport와 확대 환경에서 화면 밖으로 밀려나지 않아야 한다. 긴 콘텐츠는 제목·주요 action의 문맥을 잃지 않도록 스크롤 소유자를 명확히 하고, 포커스된 요소가 sticky 영역이나 viewport에 가려지지 않게 한다. [WCAG 2.2 Reflow와 Focus Not Obscured](https://www.w3.org/TR/WCAG22/)
+
+### 접근성
+
+초기 포커스는 콘텐츠를 먼저 읽어야 하는지, 가장 안전한 action이 무엇인지에 따라 달라진다. 파괴적 확인에서는 되돌릴 수 없는 action으로 자동 포커스하지 않는 것이 APG의 informative 권고다. 명시적 닫기 버튼은 아이콘만 보여도 정확한 접근 가능한 이름을 가져야 한다. [APG Dialog Pattern (informative)](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/)
+
+`aria-modal="true"`는 배경을 실제로 inert하게 만드는 기능이 아니다. 커스텀 ARIA dialog는 focus, pointer, accessibility tree의 배경 접근을 구현에서 함께 차단해야 한다. 반대로 네이티브 modal dialog는 브라우저가 같은 문서의 나머지를 inert하게 처리한다. [`aria-modal` 명세](https://www.w3.org/TR/wai-aria/#aria-modal), [`showModal()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement/showModal)
+
+### 렌더링과 브라우저
+
+네이티브 modal dialog는 top layer에 배치되므로 일반 stacking context의 큰 `z-index`로 같은 동작을 재현하려 하지 않는다. [`showModal()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement/showModal) 열림·닫힘 애니메이션은 `display`, top-layer 참여, `::backdrop`의 discrete transition 특성을 고려해야 한다. [`<dialog>` 애니메이션](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dialog#animating_dialogs) 포털을 쓰는 경우 논리적 호출 관계, form 소유권, SSR hydration 위치가 보존되는지도 확인한다.
+
+## 검증 관점
+
+- dialog가 열리면 목적에 맞는 내부 요소로 포커스가 이동하는가
+- `Tab`과 `Shift+Tab`으로 배경에 도달할 수 없는가
+- 포인터와 보조 기술에서도 배경이 조작 불가능한가
+- `Escape`와 명시적 닫기 버튼이 정책에 맞게 동작하는가
+- 닫힌 뒤 호출자 또는 다음 작업 위치로 포커스가 복원되는가
+- 제목만 읽어도 dialog 목적을 알 수 있는가
+- 긴 콘텐츠, 확대, 모바일 viewport에서도 action과 포커스가 가려지지 않는가
+- 중첩 dialog를 닫을 때 가장 위 표면과 focus 복원 스택이 유지되는가
+
+## 출처
+
+- [WAI-ARIA 1.2: dialog](https://www.w3.org/TR/wai-aria/#dialog)
+- [WAI-ARIA 1.2: aria-modal](https://www.w3.org/TR/wai-aria/#aria-modal)
+- [WAI-ARIA APG Dialog Pattern (informative)](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/)
+- [APG Modal Dialog Example (informative)](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/dialog/)
+- [HTML Standard: dialog](https://html.spec.whatwg.org/multipage/interactive-elements.html#the-dialog-element)
+- [MDN `<dialog>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dialog)
+- [MDN `showModal()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement/showModal)
+- [WCAG 2.2](https://www.w3.org/TR/WCAG22/)

--- a/packages/ui/src/component/select/guide.md
+++ b/packages/ui/src/component/select/guide.md
@@ -1,0 +1,137 @@
+---
+name: select
+platform: web
+---
+
+# Select
+
+## 역할
+
+미리 정해진 선택지 집합에서 하나의 값을 선택하게 한다. 이 문서는 텍스트 편집을 지원하지 않는 select-only control을 중심으로 하며, 검색·자유 입력·자동 완성이 필요하면 editable combobox 계약을 별도로 적용한다. 네이티브 `<select>`가 제품 요구를 충족하면 플랫폼 동작, form 참여, 보조 기술 지원을 직접 활용하는 가장 단순한 선택이다. [HTML `<select>`](https://html.spec.whatwg.org/multipage/form-elements.html#the-select-element), [APG Combobox Pattern (informative)](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/)
+
+## 보장해야 하는 계약
+
+| 조건                                | 규칙                                                                                                                                                            | 근거                                                                                                                                                                                           |
+| ----------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 항상                                | control은 보이는 label과 프로그램적으로 연결된 접근 가능한 이름을 가져야 한다. placeholder나 현재 값만으로 label을 대체하지 않는다.                             | [HTML `<label>`](https://html.spec.whatwg.org/multipage/forms.html#the-label-element), [WCAG 2.2 Labels or Instructions](https://www.w3.org/TR/WCAG22/#labels-or-instructions)                 |
+| 커스텀 select-only combobox인 경우  | trigger는 `combobox` 상태를 노출하고, popup의 열림 여부와 제어 대상 관계가 실제 DOM 상태와 일치해야 한다. popup은 단일 선택이라면 보통 `listbox` 의미를 가진다. | [WAI-ARIA combobox 요구사항](https://www.w3.org/TR/wai-aria/#combobox), [APG Combobox Pattern (informative)](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/)                               |
+| listbox popup을 사용하는 경우       | 각 선택지는 `option` 의미와 선택 상태를 가지며, 단일 선택 control에서는 동시에 하나만 선택되어야 한다.                                                          | [WAI-ARIA listbox 명세](https://www.w3.org/TR/wai-aria/#listbox), [WAI-ARIA option 명세](https://www.w3.org/TR/wai-aria/#option)                                                               |
+| popup이 열린 경우                   | 키보드로 옵션을 탐색하고 확정·취소할 수 있어야 하며, 닫힌 뒤 focus는 control에 남거나 돌아와야 한다.                                                            | [APG Combobox Pattern (informative)](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/), [APG Listbox Pattern (informative)](https://www.w3.org/WAI/ARIA/apg/patterns/listbox/)               |
+| 긴 옵션 목록인 경우                 | 이름 기반 type-ahead 또는 검색 등 효율적인 탐색 수단을 검토한다. 검색을 넣으면 editable combobox라는 별도 상호작용 모델로 전환한다.                             | [APG Listbox type-ahead 권고 (informative)](https://www.w3.org/WAI/ARIA/apg/patterns/listbox/), [APG Combobox Pattern (informative)](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/)       |
+| 비활성 옵션이나 control이 있는 경우 | 비활성 상태와 실제 실행 가능 여부를 일치시키고, 필요한 설명이 비활성화 때문에 접근 불가능해지지 않게 한다.                                                      | [`disabled` 속성](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fe-disabled), [`aria-disabled` 명세](https://www.w3.org/TR/wai-aria/#aria-disabled)             |
+| form 값으로 제출되는 경우           | 화면에 표시한 label과 제출 value를 구분하고, required·validation·reset 동작을 form 계약과 일치시킨다.                                                           | [HTML `<select>`](https://html.spec.whatwg.org/multipage/form-elements.html#the-select-element), [MDN `<select>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/select) |
+
+APG combobox·listbox 패턴은 **informative 작성 지침**이고, 네이티브 `<select>`의 모든 브라우저 동작을 그대로 정의하지 않는다. 커스텀 구현은 대상 브라우저와 보조 기술에서 키보드, 이름, 상태 발표를 별도로 검증한다.
+
+## 프로젝트에서 결정할 항목
+
+| 결정                       | 적용 조건                                     | 판단에 사용하는 정보                                  |
+| -------------------------- | --------------------------------------------- | ----------------------------------------------------- |
+| 네이티브 또는 커스텀 구현  | 항상                                          | 시각 요구, 옵션 콘텐츠, 모바일 동작, 접근성 유지 비용 |
+| 초기 값과 미선택 상태      | 값이 필수가 아니거나 placeholder가 필요할 때  | form 의미, required 정책, 기본값의 제품 영향          |
+| 선택이 focus 이동을 따를지 | 커스텀 listbox 탐색을 사용할 때               | 취소 가능성, 값 변경의 부작용, 플랫폼 관례            |
+| type-ahead 또는 검색       | 옵션 수와 이름이 탐색 비용을 만들 때          | 데이터 규모, 사용자 어휘, 로딩 방식                   |
+| 그룹과 구분자              | 선택지에 의미 있는 범주가 있을 때             | 정보 구조, 그룹 label, 옵션 수                        |
+| popup 배치와 최대 높이     | popup이 viewport 또는 컨테이너 경계와 만날 때 | 반응형 Foundation, scroll owner, portal 정책          |
+| 오류·도움말 표시           | validation이 있을 때                          | Form Foundation, 제출 시점, 오류 복구                 |
+| 비동기 옵션과 loading      | 원격 데이터를 사용할 때                       | 캐시, 재시도, 빈 상태, 선택 값 보존                   |
+| 선택 직후 popup 닫기       | 단일 값을 확정할 때                           | 값 변경의 가역성, 연속 비교 필요성                    |
+
+## 토큰 결정 지도
+
+```yaml
+control:
+  color: color
+  background-color: color
+  border-color: color
+  border-width: border
+  border-radius: radius
+  typography: typography
+  padding-block: spacing
+  padding-inline: spacing
+  min-block-size: sizing
+
+indicator:
+  color: color
+  size: sizing
+  gap: spacing
+
+popup:
+  color: color
+  background-color: color
+  border-color: color
+  border-width: border
+  border-radius: radius
+  box-shadow: elevation
+  padding-block: spacing
+  max-block-size: sizing
+
+group-label:
+  color: color
+  typography: typography
+  padding: spacing
+
+option:
+  color: color
+  background-color: color
+  typography: typography
+  padding-block: spacing
+  padding-inline: spacing
+  gap: spacing
+
+separator:
+  color: color
+  thickness: border
+  margin-block: spacing
+
+focus:
+  outline-color: color
+  outline-width: border
+  outline-offset: spacing
+
+motion:
+  duration: motion
+  easing: motion
+```
+
+## 엔지니어링 지식
+
+### 의미와 동작
+
+현재 값, popup에서 탐색 중인 focus option, 확정된 selection을 분리한다. focus 이동만으로 외부 데이터 요청이나 form 제출 같은 부작용이 발생하지 않게 selection commit 시점을 명시한다. `listbox` option의 접근 가능한 이름은 평면 문자열로 전달되며 내부의 heading·button·link 의미를 상호작용할 수 없으므로, 복합 interactive 콘텐츠가 필요하면 다른 패턴을 선택한다. [APG Listbox Pattern (informative)](https://www.w3.org/WAI/ARIA/apg/patterns/listbox/)
+
+### 레이아웃
+
+control은 현재 값과 열림 표시가 긴 번역에서도 겹치지 않아야 한다. popup은 trigger 너비를 무조건 복사하기보다 옵션 가독성, viewport 경계, 제품 정렬 규칙으로 크기를 결정한다. 내부 스크롤이 있으면 키보드로 이동한 active option이 항상 보이도록 scroll position을 동기화한다.
+
+### 접근성
+
+네이티브 control이면 연결된 `<label>`과 `<option>` 의미를 보존한다. 커스텀 select-only combobox이면 `aria-expanded`, `aria-controls`, popup role, active option과 selection 상태를 한 상태 모델에서 갱신한다. DOM focus를 option으로 옮기는 방식과 control에 유지하며 `aria-activedescendant`를 쓰는 방식을 섞지 않는다. [WAI-ARIA combobox](https://www.w3.org/TR/wai-aria/#combobox), [`aria-activedescendant`](https://www.w3.org/TR/wai-aria/#aria-activedescendant)
+
+`Escape` 취소, `Enter`·`Space` 확정, 화살표 탐색, 입력 문자 기반 이동은 채택한 패턴과 플랫폼에 맞게 일관되게 제공한다. 정확한 키 조합은 APG의 informative combobox·listbox 지침과 실제 네이티브 동작을 비교해 결정한다. [APG Combobox Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/), [APG Listbox Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/listbox/)
+
+### 렌더링과 브라우저
+
+popup을 portal로 렌더링하면 trigger와 popup의 프로그램적 관계, DOM 읽기 순서, focus 복원, scroll clipping을 확인한다. 모바일 브라우저의 네이티브 `<select>`는 데스크톱과 다른 시스템 picker를 사용할 수 있으므로 커스텀 UI와 동일한 화면을 가정하지 않는다. 서버 렌더링 시 초기 선택 값과 form value가 클라이언트 상태와 같아야 한다.
+
+## 검증 관점
+
+- label, 현재 값, 열림 상태가 보조 기술에 구분되어 전달되는가
+- 키보드만으로 열기, 탐색, 확정, 취소할 수 있는가
+- 탐색 focus와 확정 selection이 제품 정책대로 구분되는가
+- 선택된 option이 하나만 존재하고 trigger 값과 일치하는가
+- 비활성 option을 포인터·키보드·프로그램 호출로 확정할 수 없는가
+- 긴 옵션과 확대 환경에서 값과 표시자가 겹치지 않는가
+- popup 경계에서 active option이 스크롤 영역 안에 보이는가
+- form reset, validation, 제출 값이 시각 상태와 일치하는가
+
+## 출처
+
+- [HTML Standard: `select`](https://html.spec.whatwg.org/multipage/form-elements.html#the-select-element)
+- [HTML Standard: `label`](https://html.spec.whatwg.org/multipage/forms.html#the-label-element)
+- [WAI-ARIA 1.2: combobox](https://www.w3.org/TR/wai-aria/#combobox)
+- [WAI-ARIA 1.2: listbox](https://www.w3.org/TR/wai-aria/#listbox)
+- [WAI-ARIA APG Combobox Pattern (informative)](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/)
+- [WAI-ARIA APG Listbox Pattern (informative)](https://www.w3.org/WAI/ARIA/apg/patterns/listbox/)
+- [MDN `<select>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/select)
+- [WCAG 2.2](https://www.w3.org/TR/WCAG22/)

--- a/packages/ui/src/component/slider/guide.md
+++ b/packages/ui/src/component/slider/guide.md
@@ -1,0 +1,111 @@
+---
+name: slider
+platform: web
+---
+
+# Slider
+
+## 역할
+
+Slider는 제한된 연속 또는 단계 범위 안에서 값을 고르게 한다. HTML의 `input type="range"`는 정확한 값 자체가 중요하지 않은 숫자 선택을 위한 컨트롤이다. 정확한 직접 입력이 핵심이면 number 또는 text 입력과의 결합을 검토한다. [HTML Standard](<https://html.spec.whatwg.org/multipage/input.html#range-state-(type=range)>)
+
+## 보장해야 하는 계약
+
+| 조건                                         | 규칙                                                                                                                                                                      | 근거                                                                                                                                                                                                    |
+| -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 단일 숫자 범위이고 네이티브 기능이 충분할 때 | `input type="range"`의 값 보정, 키보드, 폼, 접근성 의미를 보존한다.                                                                                                       | [HTML Standard](<https://html.spec.whatwg.org/multipage/input.html#range-state-(type=range)>), [ARIA in HTML](https://www.w3.org/TR/html-aria/)                                                         |
+| 항상                                         | 최소값, 최대값, 현재값과 step 규칙이 일관되고 현재값은 허용 범위 안에 있어야 한다.                                                                                        | [HTML Standard](<https://html.spec.whatwg.org/multipage/input.html#range-state-(type=range)>), [WAI-ARIA slider role](https://www.w3.org/TR/wai-aria/#slider)                                           |
+| 값 의미가 숫자만으로 이해되지 않을 때        | 화면과 보조 기술에 단위 또는 사람이 이해할 값 표현을 제공한다. 커스텀 slider에서는 필요 시 `aria-valuetext`를 사용한다.                                                   | [WAI-ARIA `aria-valuetext`](https://www.w3.org/TR/wai-aria/#aria-valuetext), [APG Slider Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/slider/)                                                     |
+| 커스텀 slider일 때                           | focusable thumb에 slider 역할, 이름, 현재·최소·최대값, 방향을 노출하고 키보드로 step 이동과 범위 끝 이동을 제공한다. APG 키 모델은 비규범 권고다.                         | [WAI-ARIA slider role](https://www.w3.org/TR/wai-aria/#slider), [APG Slider Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/slider/), [APG 소개](https://www.w3.org/WAI/ARIA/apg/about/introduction/) |
+| 드래그로 값을 바꿀 때                        | 드래그 없이 단일 포인터로 같은 기능을 수행할 방법을 제공한다. 사용자 에이전트가 결정하고 수정하지 않은 기능에는 WCAG 예외가 있다.                                         | [WCAG 2.2 2.5.7](https://www.w3.org/TR/WCAG22/#dragging-movements)                                                                                                                                      |
+| 다중 thumb일 때                              | 각 thumb에 고유한 이름과 값을 제공하고, 값 의존성이 있으면 각 thumb의 유효 범위를 동기화하며 논리적 tab 순서를 안정적으로 유지한다. APG multi-thumb 모델은 비규범 권고다. | [APG Multi-Thumb Slider Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/slider-multithumb/), [APG 소개](https://www.w3.org/WAI/ARIA/apg/about/introduction/)                                          |
+| 포인터로 조작할 때                           | thumb와 대체 컨트롤은 목표 크기 또는 간격 요구를 만족해야 한다.                                                                                                           | [WCAG 2.2 2.5.8](https://www.w3.org/TR/WCAG22/#target-size-minimum)                                                                                                                                     |
+| 시각 외형을 사용자 정의할 때                 | track, thumb, 현재 범위, focus를 식별하는 데 필요한 시각 정보는 충분히 구분되어야 한다.                                                                                   | [WCAG 2.2 1.4.11](https://www.w3.org/TR/WCAG22/#non-text-contrast), [WCAG 2.2 2.4.7](https://www.w3.org/TR/WCAG22/#focus-visible)                                                                       |
+
+## 프로젝트에서 결정할 항목
+
+| 결정                          | 적용 조건                              | 판단에 사용하는 정보                   |
+| ----------------------------- | -------------------------------------- | -------------------------------------- |
+| Slider가 적합한 정밀도        | 모든 사용처                            | 값의 의미, 허용 오차, 직접 입력 필요성 |
+| 최소·최대·step·초기값         | 모든 사용처                            | 도메인 제약, 데이터 타입, 국제화       |
+| 현재값과 단위 표시            | 숫자만으로 의미가 불명확할 때          | 콘텐츠 전략, 단위 형식, 현지화         |
+| 직접 입력 또는 증감 대안      | 정밀 입력이나 드래그 대안이 필요할 때  | 오류 비용, 터치 사용성, 폼 구조        |
+| 단일·다중 thumb               | 범위의 한 값 또는 양 끝을 고를 때      | 도메인 모델, 값 상호 의존성            |
+| 수평·수직 방향과 값 증가 방향 | 레이아웃이나 도메인이 방향성을 가질 때 | writing mode, locale, 물리적 은유      |
+| tick과 구간 레이블            | 중요한 이산 값이 있을 때               | 데이터 분포, 콘텐츠 밀도               |
+
+## 토큰 결정 지도
+
+```yaml
+root:
+  min-size: sizing
+track:
+  background-color: color
+  thickness: sizing
+  border-radius: radius
+range:
+  background-color: color
+thumb:
+  color: color
+  background-color: color
+  border-color: color
+  border-width: border
+  size: sizing
+  border-radius: radius
+label:
+  color: color
+  typography: typography
+layout:
+  control-label-gap: spacing
+  value-gap: spacing
+focus:
+  outline-color: color
+  outline-width: border
+  outline-offset: spacing
+state:
+  disabled-opacity: opacity
+motion:
+  transition-duration: motion
+  transition-timing-function: motion
+```
+
+## 엔지니어링 지식
+
+### 의미와 동작
+
+도메인 값을 먼저 정규화한 뒤 시각 위치를 계산한다. 부동소수점 step에서는 표시 문자열과 내부 계산을 분리해 누적 오차가 사용자에게 노출되지 않게 한다. 네이티브 range는 잘못된 값과 step mismatch를 표준 규칙으로 보정하므로 이를 감싸는 상태 모델이 서로 다른 값을 유지하지 않게 한다. [HTML Standard](<https://html.spec.whatwg.org/multipage/input.html#range-state-(type=range)>)
+
+### 레이아웃
+
+thumb의 시각 크기와 실제 hit target을 구분해 설계하고, 컨테이너 경계에서 focus indicator나 thumb가 잘리지 않게 한다. 수직 slider는 단순 회전만으로 끝내지 말고 논리 축, writing mode, 키 방향, 접근성 방향을 함께 맞춘다. 네이티브 range의 구체적인 렌더링은 사용자 에이전트가 달리할 수 있다. [HTML Standard](<https://html.spec.whatwg.org/multipage/input.html#range-state-(type=range)>)
+
+### 접근성
+
+값이 바뀔 때마다 전체 페이지에 과도한 live announcement를 만들지 않고 slider 자체의 현재값으로 전달한다. 다중 thumb는 각각 구별 가능한 이름을 가져야 한다. APG는 touch 기반 보조 기술이 커스텀 slider 제스처를 충분히 전달하지 못할 수 있다고 경고하므로 실제 지원 기기와 보조 기술에서 시험한다. 이는 APG의 비규범 운영 지침이다. [APG Slider Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/slider/), [APG Multi-Thumb Slider Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/slider-multithumb/), [APG 소개](https://www.w3.org/WAI/ARIA/apg/about/introduction/)
+
+### 렌더링과 브라우저
+
+브라우저별 range pseudo-element와 외형 차이는 별도의 호환성 계층으로 다룬다. 기본 외형을 제거하면 thumb, track, focus, disabled, 강제 색상 표현을 모두 책임져야 한다. 강제 색상 모드에서는 색과 그림자가 바뀌거나 제거될 수 있다. [MDN `input type="range"`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/range), [MDN `forced-colors`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/forced-colors)
+
+## 검증 관점
+
+- 키보드로 step 단위 이동과 최소·최대 이동이 가능한가
+- 드래그 없이 단일 포인터로 값을 바꿀 수 있는가
+- 현재값, 화면 표시, 폼 값, 접근성 값이 일치하는가
+- 단위나 비선형 의미가 보조 기술에도 이해 가능한 문자열로 전달되는가
+- 다중 thumb의 이름, 유효 범위, tab 순서가 값 변화 후에도 안정적인가
+- 터치와 확대 환경에서 thumb를 정확히 조작할 수 있는가
+- 강제 색상 모드에서 track, range, thumb, focus를 구분할 수 있는가
+
+## 출처
+
+- [HTML Standard: Range state](<https://html.spec.whatwg.org/multipage/input.html#range-state-(type=range)>)
+- [ARIA in HTML](https://www.w3.org/TR/html-aria/)
+- [WAI-ARIA: slider role](https://www.w3.org/TR/wai-aria/#slider)
+- [WCAG 2.2](https://www.w3.org/TR/WCAG22/)
+- [APG Slider Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/slider/)
+- [APG Multi-Thumb Slider Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/slider-multithumb/)
+- [APG Introduction](https://www.w3.org/WAI/ARIA/apg/about/introduction/)
+- [Carbon Design System: Slider](https://carbondesignsystem.com/components/slider/usage/)
+- [MDN: `input type="range"`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/range)
+- [MDN: `forced-colors`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/forced-colors)

--- a/packages/ui/src/component/tabs/guide.md
+++ b/packages/ui/src/component/tabs/guide.md
@@ -1,0 +1,127 @@
+---
+name: tabs
+platform: web
+---
+
+# Tabs
+
+## 역할
+
+서로 관련되고 비슷한 중요도를 가진 콘텐츠 패널을 한 자리에서 전환한다. 한 번에 하나의 패널을 보여 주는 정보 구조이며, 페이지 간 주요 탐색이나 순차 작업 흐름을 대신하지 않는다. [Spectrum은 관련 콘텐츠를 하나의 일관된 단위로 묶고 서로 다른 중요도의 콘텐츠나 flow에 사용하지 않도록 안내한다](https://spectrum.adobe.com/page/tabs/).
+
+## 보장해야 하는 계약
+
+| 조건                                              | 규칙                                                                                                                                          | 근거                                                                                                                                                                                    |
+| ------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 항상                                              | tab 집합, 각 tab, 대응 panel에 각각 `tablist`, `tab`, `tabpanel` 의미를 제공하고 tab과 panel의 이름·제어 관계를 연결한다.                     | [WAI-ARIA `tablist`](https://www.w3.org/TR/wai-aria/#tablist), [`tab`](https://www.w3.org/TR/wai-aria/#tab), [`tabpanel`](https://www.w3.org/TR/wai-aria/#tabpanel)                     |
+| 항상                                              | 활성 tab 하나의 `aria-selected`만 `true`이고, 표시되는 panel과 일치해야 한다. 비활성 panel은 사용자에게 활성 콘텐츠처럼 노출되지 않아야 한다. | [WAI-ARIA `tab` role](https://www.w3.org/TR/wai-aria/#tab), [APG Tabs Pattern (informative)](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/)                                            |
+| 키보드 focus가 tablist에 들어올 때                | 일반적으로 활성 tab이 하나의 tab stop이 되고, 방향키로 같은 tablist의 tab 사이를 이동한다.                                                    | [APG Tabs Pattern (informative)](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/), [APG Keyboard Interface (informative)](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/) |
+| 수직 방향을 지원하는 경우                         | orientation을 프로그램적으로 제공하고, 키보드 이동 축을 시각 방향과 일치시킨다.                                                               | [`aria-orientation` 명세](https://www.w3.org/TR/wai-aria/#aria-orientation), [APG Tabs Pattern (informative)](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/)                           |
+| 자동 활성화를 사용하는 경우                       | focus된 panel이 지연 없이 표시되어야 한다. 네트워크·렌더링 지연이 있으면 focus 이동과 panel 활성화를 분리하는 수동 활성화를 사용한다.         | [APG Tabs Pattern의 activation latency 권고 (informative)](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/)                                                                              |
+| panel의 첫 의미 있는 콘텐츠가 focus 불가능한 경우 | tablist 다음의 키보드 사용자가 panel 콘텐츠로 이동할 수 있도록 panel 자체를 tab 순서에 포함하는 방식을 검토한다.                              | [APG Tabs Pattern (informative)](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/)                                                                                                        |
+| 활성 상태를 시각화하는 경우                       | 색상 하나에만 의존하지 않고 focus와 selection을 서로 구분한다.                                                                                | [WCAG 2.2 Use of Color, Non-text Contrast, Focus Visible](https://www.w3.org/TR/WCAG22/)                                                                                                |
+
+APG tabs pattern은 **informative 작성 지침**이며 키보드 모델을 구현하는 예시이지 브라우저가 자동 제공하는 동작이 아니다. 커스텀 tab은 대상 브라우저와 보조 기술에서 roving focus와 panel 관계를 검증한다.
+
+## 프로젝트에서 결정할 항목
+
+| 결정                  | 적용 조건                                    | 판단에 사용하는 정보                                 |
+| --------------------- | -------------------------------------------- | ---------------------------------------------------- |
+| 자동 또는 수동 활성화 | 키보드 방향키 탐색이 있을 때                 | panel 표시 지연, preload 정책, 데이터 비용           |
+| 가로 또는 세로 방향   | 공간과 콘텐츠 구조에 따라                    | 반응형 Foundation, label 길이, 읽기 방향             |
+| overflow 처리         | tab이 사용 가능한 축을 넘을 때               | tab 수, 좁은 화면, 접근성 있는 스크롤·대체 picker    |
+| panel DOM 유지 여부   | panel에 로컬 상태나 비용 큰 콘텐츠가 있을 때 | 상태 보존, 성능, 보조 기술 노출                      |
+| 초기 활성 tab         | 최초 렌더링 또는 복원 시                     | URL, 사용자 상태, validation 오류, 제품 기본값       |
+| tab label과 선택 표시 | 항상                                         | Content guideline, Icon Foundation, Color Foundation |
+| 비활성 tab 처리       | 사용할 수 없는 panel이 있을 때               | 사유 전달, 작업 순서, 대체 접근 경로                 |
+| tab 추가·닫기         | 동적 workspace를 지원할 때                   | focus 복원, 데이터 손실, 별도 action UI              |
+| 선택 표시 모션        | 활성 tab이 바뀔 때                           | Motion Foundation, reduced-motion 정책, 즉시성       |
+
+## 토큰 결정 지도
+
+```yaml
+root:
+  color: color
+  background-color: color
+
+list:
+  background-color: color
+  border-color: color
+  border-width: border
+  border-radius: radius
+  gap: spacing
+  padding: spacing
+
+tab:
+  color: color
+  background-color: color
+  typography: typography
+  padding-block: spacing
+  padding-inline: spacing
+  gap: spacing
+  min-block-size: sizing
+  border-radius: radius
+
+selection-indicator:
+  color: color
+  thickness: border
+  offset: spacing
+
+panel:
+  color: color
+  background-color: color
+  typography: typography
+  padding-block: spacing
+  margin-block-start: spacing
+
+focus:
+  outline-color: color
+  outline-width: border
+  outline-offset: spacing
+
+motion:
+  duration: motion
+  easing: motion
+```
+
+## 엔지니어링 지식
+
+### 의미와 동작
+
+focus된 tab과 selected tab은 수동 활성화에서 서로 다를 수 있다. 키보드 focus 상태를 selection 상태에서 파생하지 말고, activation mode에 따라 명시적으로 전환한다. tab·panel 식별자는 SSR과 hydration을 거쳐 안정적이어야 하며, 한 tab의 label과 제어 대상이 다른 인스턴스와 충돌하지 않게 한다.
+
+### 레이아웃
+
+tab label은 번역과 텍스트 확대를 견뎌야 한다. 여러 label을 잘라 억지로 한 줄에 맞추기보다 접근 가능한 horizontal scroll, 세로 배치, 별도 picker 등 프로젝트에 맞는 overflow 전략을 선택한다. Spectrum은 좁은 공간에서 horizontal scroll이나 picker를 제안하며 여러 tab label을 동시에 잘라 맞추지 않도록 안내한다. [Spectrum Tabs](https://spectrum.adobe.com/page/tabs/)
+
+### 접근성
+
+가로 tablist에서는 `Left`·`Right`, 세로 tablist에서는 `Up`·`Down`으로 이동하는 APG의 informative 관례를 우선 검토한다. `Home`·`End` 지원은 선택 사항이다. 수동 활성화에서는 `Enter` 또는 `Space`가 focused tab을 활성화한다. 방향키 처리 시 가로 목록의 `Up`·`Down` 같은 브라우저 스크롤 키를 불필요하게 가로채지 않는다. [APG Tabs Pattern (informative)](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/)
+
+아이콘만 있는 tab을 허용하면 시각 label과 동등한 접근 가능한 이름을 제공한다. focus indicator와 selected indicator가 동시에 나타날 수 있으므로 두 상태를 구별 가능하게 설계한다. [Spectrum Tabs label 지침](https://spectrum.adobe.com/page/tabs/), [WCAG 2.2 Focus Visible](https://www.w3.org/TR/WCAG22/#focus-visible)
+
+### 렌더링과 브라우저
+
+비활성 panel을 CSS로만 화면 밖에 배치하면 보조 기술이나 검색·focus 순서에 남을 수 있다. 숨김 방식이 접근성 트리와 focusability를 함께 제어하는지 확인한다. panel을 지연 로드할 때 자동 활성화 focus 이동을 막을 정도의 latency가 생기면 수동 활성화로 전환한다. URL과 활성 tab을 동기화할 경우 브라우저 뒤로 가기, deep link, 초기 hydration의 우선순위를 명시한다.
+
+## 검증 관점
+
+- 한 tab만 selected이고 표시되는 panel과 정확히 대응하는가
+- tab과 panel의 accessible name·control 관계가 인스턴스마다 유일한가
+- `Tab`은 tablist에 한 번 진입하고 방향키가 내부 focus를 이동하는가
+- 수동 활성화에서 방향키 focus가 값을 즉시 바꾸지 않는가
+- 자동 활성화에서 panel이 지연 없이 표시되는가
+- 가로·세로 방향과 키보드 이동 축이 일치하는가
+- 긴 번역, 확대, 좁은 화면에서 모든 tab에 접근할 수 있는가
+- focus와 selected 표시를 동시에 구별할 수 있는가
+- 비활성 panel의 컨트롤이 키보드 순서에 남지 않는가
+
+## 출처
+
+- [WAI-ARIA 1.2: tablist](https://www.w3.org/TR/wai-aria/#tablist)
+- [WAI-ARIA 1.2: tab](https://www.w3.org/TR/wai-aria/#tab)
+- [WAI-ARIA 1.2: tabpanel](https://www.w3.org/TR/wai-aria/#tabpanel)
+- [WAI-ARIA APG Tabs Pattern (informative)](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/)
+- [APG Keyboard Interface (informative)](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/)
+- [WCAG 2.2](https://www.w3.org/TR/WCAG22/)
+- [Spectrum Tabs](https://spectrum.adobe.com/page/tabs/)

--- a/packages/ui/src/component/textfield/guide.md
+++ b/packages/ui/src/component/textfield/guide.md
@@ -1,0 +1,114 @@
+---
+name: textfield
+platform: web
+---
+
+# TextField
+
+## 역할
+
+TextField는 사용자가 한 줄의 자유 형식 텍스트 값을 입력하고 편집하게 한다. HTML의 `input type="text"`는 한 줄 plain-text edit control이며 줄바꿈 문자를 허용하지 않는다. 여러 줄 입력이나 미리 정해진 선택지는 다른 컨트롤의 책임이다. [HTML Standard](<https://html.spec.whatwg.org/multipage/input.html#text-(type=text)>)
+
+## 보장해야 하는 계약
+
+| 조건                           | 규칙                                                                                                                                        | 근거                                                                                                                                                                                                                                             |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 항상                           | 입력 목적에 맞는 네이티브 `input` 유형을 선택하고 브라우저의 편집, 선택, 자동완성, 폼, 키보드 동작을 보존한다.                              | [HTML Standard: input types](https://html.spec.whatwg.org/multipage/input.html#states-of-the-type-attribute), [WCAG 2.2 1.3.5](https://www.w3.org/TR/WCAG22/#identify-input-purpose)                                                             |
+| 사용자 입력을 요구할 때        | 입력 목적을 설명하는 레이블 또는 지시문을 제공하고 컨트롤과 프로그램적으로 연결한다.                                                        | [HTML Standard: label](https://html.spec.whatwg.org/multipage/forms.html#the-label-element), [WCAG 2.2 3.3.2](https://www.w3.org/TR/WCAG22/#labels-or-instructions)                                                                              |
+| placeholder를 사용할 때        | placeholder를 지속 레이블이나 필수 형식 지시문의 유일한 수단으로 사용하지 않는다.                                                           | [WCAG Technique H44](https://www.w3.org/WAI/WCAG22/Techniques/html/H44), [Carbon Text Input](https://carbondesignsystem.com/components/text-input/usage/)                                                                                        |
+| 도움말이나 형식 지시가 있을 때 | 관련 텍스트를 컨트롤과 프로그램적으로 연결하고 입력 전에 알아야 하는 조건은 지속적으로 접근 가능하게 한다.                                  | [WCAG 2.2 1.3.1](https://www.w3.org/TR/WCAG22/#info-and-relationships), [WCAG 2.2 3.3.2](https://www.w3.org/TR/WCAG22/#labels-or-instructions)                                                                                                   |
+| 오류를 자동 감지할 때          | 오류가 난 항목을 식별하고 오류 내용을 텍스트로 설명하며, 유효성 상태와 오류 메시지 관계를 보조 기술에 전달한다.                             | [WCAG 2.2 3.3.1](https://www.w3.org/TR/WCAG22/#error-identification), [WAI-ARIA `aria-invalid`](https://www.w3.org/TR/wai-aria/#aria-invalid), [WAI-ARIA `aria-errormessage`](https://www.w3.org/TR/wai-aria/#aria-errormessage)                 |
+| 필수 입력일 때                 | 필수 여부를 시각적으로만 표시하지 않고 프로그램적 상태와 지시문으로도 전달한다.                                                             | [HTML Standard: required](https://html.spec.whatwg.org/multipage/input.html#attr-input-required), [WCAG 2.2 1.3.1](https://www.w3.org/TR/WCAG22/#info-and-relationships), [WCAG 2.2 3.3.2](https://www.w3.org/TR/WCAG22/#labels-or-instructions) |
+| 앞뒤 부가 요소가 있을 때       | 장식은 접근 가능한 이름을 오염시키지 않고, 정보성 단위·접두·접미는 입력 의미와 연결하며, 대화형 요소는 독립된 이름과 focus target을 갖는다. | [WCAG 2.2 1.3.1](https://www.w3.org/TR/WCAG22/#info-and-relationships), [WCAG 2.2 4.1.2](https://www.w3.org/TR/WCAG22/#name-role-value)                                                                                                          |
+| 사용자 정의 외형을 적용할 때   | 입력 경계, 상태, focus를 식별하는 시각 정보가 충분히 구분되고 색 하나에만 의존하지 않아야 한다.                                             | [WCAG 2.2 1.4.11](https://www.w3.org/TR/WCAG22/#non-text-contrast), [WCAG 2.2 1.4.1](https://www.w3.org/TR/WCAG22/#use-of-color), [WCAG 2.2 2.4.7](https://www.w3.org/TR/WCAG22/#focus-visible)                                                  |
+
+## 프로젝트에서 결정할 항목
+
+| 결정                            | 적용 조건                       | 판단에 사용하는 정보                                 |
+| ------------------------------- | ------------------------------- | ---------------------------------------------------- |
+| 네이티브 입력 유형과 input mode | 모든 필드                       | 데이터 의미, 유효 형식, 모바일 키보드, 자동완성 정책 |
+| 지속 레이블, 도움말, 예시 문구  | 모든 필드                       | 콘텐츠 전략, 폼 복잡도, 사용자 연구                  |
+| 필수·선택 표기 방식             | 폼에 두 종류가 공존할 때        | 폼 정책, 법적 요구, 콘텐츠 Foundation                |
+| 검증 시점                       | 유효성 검사가 있을 때           | 오류 비용, 서버 규칙, 사용자 흐름                    |
+| 오류 메시지 발표 방식           | 동적으로 오류가 생길 때         | 제출 흐름, focus 이동, live region 정책              |
+| leading·trailing content 역할   | 단위, 아이콘, 버튼을 포함할 때  | 데이터 의미, Icon Foundation, 명령 경계              |
+| 너비와 밀도                     | 다양한 예상 입력 길이가 있을 때 | 데이터 길이, 레이아웃, Typography, Spacing           |
+| 읽기 전용과 비활성              | 수정 불가 값을 표시할 때        | 복사 필요성, 제출 정책, 권한 모델                    |
+
+## 토큰 결정 지도
+
+```yaml
+root:
+  width: sizing
+label:
+  color: color
+  typography: typography
+field:
+  color: color
+  background-color: color
+  border-color: color
+  border-width: border
+  border-radius: radius
+  min-size: sizing
+  padding-block: spacing
+  padding-inline: spacing
+  typography: typography
+content:
+  gap: spacing
+helper:
+  color: color
+  typography: typography
+  gap: spacing
+icon:
+  color: color
+  size: sizing
+focus:
+  outline-color: color
+  outline-width: border
+  outline-offset: spacing
+state:
+  disabled-opacity: opacity
+motion:
+  transition-duration: motion
+  transition-timing-function: motion
+```
+
+## 엔지니어링 지식
+
+### 의미와 동작
+
+데이터가 한 줄 자유 입력인지부터 확인한다. 이메일, URL, 전화번호처럼 목적이 명확하면 적절한 네이티브 type과 autocomplete token을 검토하고, 특정 형식을 강제할 때는 사용자가 입력 전에 조건을 알 수 있게 한다. controlled 상태를 사용할 때도 IME composition, selection, undo, autofill 같은 브라우저 편집 동작을 깨지 않도록 한다. `type="text"`에는 selection API와 input/change events가 적용된다. [HTML Standard](<https://html.spec.whatwg.org/multipage/input.html#text-(type=text)>)
+
+### 레이아웃
+
+레이블, 입력, 도움말, 오류를 하나의 읽기 흐름으로 배치한다. 예상 데이터 길이는 필드 너비 결정의 근거지만 입력 가능한 최대 길이와 동일하지 않다. 앞뒤 요소가 줄어들 때 실제 입력 영역이 사라지지 않게 하고, 긴 값은 네이티브 수평 편집과 caret 추적을 방해하지 않는다. Carbon도 한 줄 입력과 여러 줄 입력을 기대 콘텐츠 길이로 구분하고, placeholder를 레이블 대체로 쓰지 않도록 권고한다. 이는 디자인 시스템 참고 지침이다. [Carbon Text Input](https://carbondesignsystem.com/components/text-input/usage/)
+
+### 접근성
+
+오류가 있다는 사실만 live region으로 반복 발표하지 말고 필드 이름, 유효성 상태, 구체적 오류 텍스트의 관계를 유지한다. 자동 감지된 오류는 텍스트로 설명되어야 한다. 필드가 포커스를 얻는 것만으로 예기치 않은 문맥 변화를 만들지 않는다. [WCAG 2.2 3.3.1](https://www.w3.org/TR/WCAG22/#error-identification), [WCAG 2.2 3.2.1](https://www.w3.org/TR/WCAG22/#on-focus)
+
+### 렌더링과 브라우저
+
+브라우저의 autofill, spellcheck, writing direction, high contrast, zoom 상태를 포함해 확인한다. 컨테이너의 `focus-within` 스타일은 실제 input focus indicator를 대체할 수 있을 만큼 명확해야 하며 overflow에 잘리지 않아야 한다. 강제 색상 모드에서는 box shadow가 제거되고 여러 색이 시스템 색으로 강제될 수 있다. [HTML Standard](<https://html.spec.whatwg.org/multipage/input.html#text-(type=text)>), [MDN `forced-colors`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/forced-colors)
+
+## 검증 관점
+
+- 레이블을 활성화하면 정확한 input에 포커스가 가는가
+- 스크린 리더에서 이름, 도움말, 필수 여부, 오류가 올바른 순서와 관계로 전달되는가
+- placeholder가 사라진 뒤에도 입력 목적과 형식을 알 수 있는가
+- IME 입력, 붙여넣기, undo, autofill, password manager가 상태 모델과 충돌하지 않는가
+- 긴 값과 텍스트 확대에서 caret과 입력 내용이 사용 가능하게 유지되는가
+- leading·trailing interactive element가 독립적으로 포커스되고 명확한 이름을 갖는가
+- 강제 색상 모드에서도 입력 경계, 오류, focus를 구분할 수 있는가
+
+## 출처
+
+- [HTML Standard: Text state](<https://html.spec.whatwg.org/multipage/input.html#text-(type=text)>)
+- [HTML Standard: The label element](https://html.spec.whatwg.org/multipage/forms.html#the-label-element)
+- [HTML Standard: Input types](https://html.spec.whatwg.org/multipage/input.html#states-of-the-type-attribute)
+- [WAI-ARIA: `aria-invalid`](https://www.w3.org/TR/wai-aria/#aria-invalid)
+- [WAI-ARIA: `aria-errormessage`](https://www.w3.org/TR/wai-aria/#aria-errormessage)
+- [WCAG 2.2](https://www.w3.org/TR/WCAG22/)
+- [WCAG Technique H44](https://www.w3.org/WAI/WCAG22/Techniques/html/H44)
+- [Carbon Design System: Text Input](https://carbondesignsystem.com/components/text-input/usage/)
+- [MDN: `forced-colors`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/forced-colors)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,28 +107,28 @@ importers:
     dependencies:
       lucide-react:
         specifier: ^0.475.0
-        version: 0.475.0(@types/react@19.2.14)(react@19.2.5)
+        version: 0.475.0(@types/react@19.2.17)(react@19.2.7)
       motion:
         specifier: ^12.4.10
-        version: 12.38.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 12.38.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next:
-        specifier: 15.1.4
-        version: 15.1.4(@babel/core@7.29.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        specifier: 16.2.10
+        version: 16.2.10(@babel/core@7.29.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next-themes:
         specifier: ^0.4.4
-        version: 0.4.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 0.4.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       panda-animation:
         specifier: workspace:*
         version: link:../../packages/panda-animation
       radix-ui:
         specifier: ^1.1.2
-        version: 1.4.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 1.4.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react:
-        specifier: ^19.0.0
-        version: 19.2.5
+        specifier: ^19.2.7
+        version: 19.2.7
       react-dom:
-        specifier: ^19.0.0
-        version: 19.2.5(react@19.2.5)
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
     devDependencies:
       '@jongh/eslint':
         specifier: workspace:*
@@ -161,11 +161,11 @@ importers:
         specifier: ^20
         version: 20.19.39
       '@types/react':
-        specifier: ^19
-        version: 19.2.14
+        specifier: ^19.2.17
+        version: 19.2.17
       '@types/react-dom':
-        specifier: ^19
-        version: 19.2.3(@types/react@19.2.14)
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
       velite:
         specifier: ^0.2.2
         version: 0.2.4
@@ -1218,22 +1218,10 @@ packages:
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
     engines: {node: '>=18'}
 
-  '@img/sharp-darwin-arm64@0.33.5':
-    resolution: {integrity: sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm64]
-    os: [darwin]
-
   '@img/sharp-darwin-arm64@0.34.5':
     resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
-    os: [darwin]
-
-  '@img/sharp-darwin-x64@0.33.5':
-    resolution: {integrity: sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
     os: [darwin]
 
   '@img/sharp-darwin-x64@0.34.5':
@@ -1242,19 +1230,9 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-libvips-darwin-arm64@1.0.4':
-    resolution: {integrity: sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==}
-    cpu: [arm64]
-    os: [darwin]
-
   '@img/sharp-libvips-darwin-arm64@1.2.4':
     resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
     cpu: [arm64]
-    os: [darwin]
-
-  '@img/sharp-libvips-darwin-x64@1.0.4':
-    resolution: {integrity: sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==}
-    cpu: [x64]
     os: [darwin]
 
   '@img/sharp-libvips-darwin-x64@1.2.4':
@@ -1262,19 +1240,9 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-libvips-linux-arm64@1.0.4':
-    resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
-    cpu: [arm64]
-    os: [linux]
-
   '@img/sharp-libvips-linux-arm64@1.2.4':
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
-    os: [linux]
-
-  '@img/sharp-libvips-linux-arm@1.0.5':
-    resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
-    cpu: [arm]
     os: [linux]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
@@ -1292,19 +1260,9 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@img/sharp-libvips-linux-s390x@1.0.4':
-    resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
-    cpu: [s390x]
-    os: [linux]
-
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
-    os: [linux]
-
-  '@img/sharp-libvips-linux-x64@1.0.4':
-    resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
-    cpu: [x64]
     os: [linux]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
@@ -1312,19 +1270,9 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
-    resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
-    cpu: [arm64]
-    os: [linux]
-
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
-    os: [linux]
-
-  '@img/sharp-libvips-linuxmusl-x64@1.0.4':
-    resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
-    cpu: [x64]
     os: [linux]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
@@ -1332,22 +1280,10 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@img/sharp-linux-arm64@0.33.5':
-    resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm64]
-    os: [linux]
-
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
-    os: [linux]
-
-  '@img/sharp-linux-arm@0.33.5':
-    resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm]
     os: [linux]
 
   '@img/sharp-linux-arm@0.34.5':
@@ -1368,22 +1304,10 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@img/sharp-linux-s390x@0.33.5':
-    resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [s390x]
-    os: [linux]
-
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
-    os: [linux]
-
-  '@img/sharp-linux-x64@0.33.5':
-    resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
     os: [linux]
 
   '@img/sharp-linux-x64@0.34.5':
@@ -1392,22 +1316,10 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@img/sharp-linuxmusl-arm64@0.33.5':
-    resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm64]
-    os: [linux]
-
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
-    os: [linux]
-
-  '@img/sharp-linuxmusl-x64@0.33.5':
-    resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
     os: [linux]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
@@ -1415,11 +1327,6 @@ packages:
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-
-  '@img/sharp-wasm32@0.33.5':
-    resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [wasm32]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1432,22 +1339,10 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@img/sharp-win32-ia32@0.33.5':
-    resolution: {integrity: sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [ia32]
-    os: [win32]
-
   '@img/sharp-win32-ia32@0.34.5':
     resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ia32]
-    os: [win32]
-
-  '@img/sharp-win32-x64@0.33.5':
-    resolution: {integrity: sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
     os: [win32]
 
   '@img/sharp-win32-x64@0.34.5':
@@ -1710,56 +1605,56 @@ packages:
   '@neoconfetti/react@1.0.0':
     resolution: {integrity: sha512-klcSooChXXOzIm+SE5IISIAn3bYzYfPjbX7D7HoqZL84oAfgREeSg5vSIaSFH+DaGzzvImTyWe1OyrJ67vik4A==}
 
-  '@next/env@15.1.4':
-    resolution: {integrity: sha512-2fZ5YZjedi5AGaeoaC0B20zGntEHRhi2SdWcu61i48BllODcAmmtj8n7YarSPt4DaTsJaBFdxQAVEVzgmx2Zpw==}
+  '@next/env@16.2.10':
+    resolution: {integrity: sha512-zLPxg9M0MEHmygpj5OuxjQ+vHMiy/K7cSp74G8ecYolmgUWw0RwN02tF56npup/+qaI8JB97hQgS/r2Hb6QwVA==}
 
   '@next/eslint-plugin-next@15.5.15':
     resolution: {integrity: sha512-ExQoBfyKMjAUQ2nuF39ryQsG26H374ZfH13dlOZqf6TaE9ycRbIm+qUbUFCliU4BtQhiqtS7cnGA1yWfPMQ+jA==}
 
-  '@next/swc-darwin-arm64@15.1.4':
-    resolution: {integrity: sha512-wBEMBs+np+R5ozN1F8Y8d/Dycns2COhRnkxRc+rvnbXke5uZBHkUGFgWxfTXn5rx7OLijuUhyfB+gC/ap58dDw==}
+  '@next/swc-darwin-arm64@16.2.10':
+    resolution: {integrity: sha512-v9IdJCa0H0mbo+8z5zwUpOk1Vj7RjkcI5uNYf5Ws1y6szf/p3Mzl9hLaST8SCt6L9h8NGnruZcd2+o0NTNwDhA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@15.1.4':
-    resolution: {integrity: sha512-7sgf5rM7Z81V9w48F02Zz6DgEJulavC0jadab4ZsJ+K2sxMNK0/BtF8J8J3CxnsJN3DGcIdC260wEKssKTukUw==}
+  '@next/swc-darwin-x64@16.2.10':
+    resolution: {integrity: sha512-17IS0jJRViROGmA9uGdNR8VPJpfbnaVG7E9qhso5jDLkmyd0lSDORWxbcKINzcFqzZqGwGtMSnrFRxBpuUYjLQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@15.1.4':
-    resolution: {integrity: sha512-JaZlIMNaJenfd55kjaLWMfok+vWBlcRxqnRoZrhFQrhM1uAehP3R0+Aoe+bZOogqlZvAz53nY/k3ZyuKDtT2zQ==}
+  '@next/swc-linux-arm64-gnu@16.2.10':
+    resolution: {integrity: sha512-GRQRsRtuciNJvB54AvvuQTiq0oZtFwa1owQqtZD8wwnGpM2L39MV22kpI72YSXLKIyY40LC66EiLFv4PiicXxg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-arm64-musl@15.1.4':
-    resolution: {integrity: sha512-7EBBjNoyTO2ipMDgCiORpwwOf5tIueFntKjcN3NK+GAQD7OzFJe84p7a2eQUeWdpzZvhVXuAtIen8QcH71ZCOQ==}
+  '@next/swc-linux-arm64-musl@16.2.10':
+    resolution: {integrity: sha512-zkN9MQYS7UQBro+FnISUq1itaQjXI9xqISzuQ+2bc921NcJ1x4yPCqrn77tVN6/dOOXaaWVX3k6/bR07pPwK+A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-x64-gnu@15.1.4':
-    resolution: {integrity: sha512-9TGEgOycqZFuADyFqwmK/9g6S0FYZ3tphR4ebcmCwhL8Y12FW8pIBKJvSwV+UBjMkokstGNH+9F8F031JZKpHw==}
+  '@next/swc-linux-x64-gnu@16.2.10':
+    resolution: {integrity: sha512-iCVJnwvrPYECvA6WM/7+oo+OiTvedIKLxtCLAZP4xZR3nXa1zmzZyLPbYCmWvpd4CvMYF1EMTafd0ii3DygLvA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-linux-x64-musl@15.1.4':
-    resolution: {integrity: sha512-0578bLRVDJOh+LdIoKvgNDz77+Bd85c5JrFgnlbI1SM3WmEQvsjxTA8ATu9Z9FCiIS/AliVAW2DV/BDwpXbtiQ==}
+  '@next/swc-linux-x64-musl@16.2.10':
+    resolution: {integrity: sha512-ov2g4H0dHY9bPoOU83m91hWT7Iq5qy13bUnyyshLU3HGR1Ownn0X9QpmDPc5iIUaahTp7f7LeGAhV4DSFtackw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-win32-arm64-msvc@15.1.4':
-    resolution: {integrity: sha512-JgFCiV4libQavwII+kncMCl30st0JVxpPOtzWcAI2jtum4HjYaclobKhj+JsRu5tFqMtA5CJIa0MvYyuu9xjjQ==}
+  '@next/swc-win32-arm64-msvc@16.2.10':
+    resolution: {integrity: sha512-DwAnhLX76HQiFFQNgWlcK+JzlnD1rZ+UK/WY0ZMI/deXpvgnesjNYrqcfo1JzBuz4Kf7o3brIBL0glI1junatA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@15.1.4':
-    resolution: {integrity: sha512-xxsJy9wzq7FR5SqPCUqdgSXiNXrMuidgckBa8nH9HtjjxsilgcN6VgXF6tZ3uEWuVEadotQJI8/9EQ6guTC4Yw==}
+  '@next/swc-win32-x64-msvc@16.2.10':
+    resolution: {integrity: sha512-0JXq3b85Jk9Jg4ntLUbXSPvoDw3gpZou7twuKdoFG2jOw635v7+IiXfTaa0TxVMyx78pUjnrVYwLgjKfX4e6/A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -3091,9 +2986,6 @@ packages:
     peerDependencies:
       '@svgr/core': '*'
 
-  '@swc/counter@0.1.3':
-    resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
-
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
@@ -3380,8 +3272,8 @@ packages:
   '@types/react@18.3.28':
     resolution: {integrity: sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==}
 
-  '@types/react@19.2.14':
-    resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+  '@types/react@19.2.17':
+    resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
 
   '@types/resolve@1.20.6':
     resolution: {integrity: sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==}
@@ -4027,10 +3919,6 @@ packages:
     peerDependencies:
       esbuild: '>=0.18'
 
-  busboy@1.6.0:
-    resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
-    engines: {node: '>=10.16.0'}
-
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
@@ -4207,13 +4095,6 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
-
-  color-string@1.9.1:
-    resolution: {integrity: sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==}
-
-  color@4.2.3:
-    resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
-    engines: {node: '>=12.5.0'}
 
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
@@ -5456,9 +5337,6 @@ packages:
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
 
-  is-arrayish@0.3.4:
-    resolution: {integrity: sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==}
-
   is-async-function@2.1.1:
     resolution: {integrity: sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==}
     engines: {node: '>= 0.4'}
@@ -6401,14 +6279,13 @@ packages:
       react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
       react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
 
-  next@15.1.4:
-    resolution: {integrity: sha512-mTaq9dwaSuwwOrcu3ebjDYObekkxRnXpuVL21zotM8qE2W0HBOdVIdg2Li9QjMEZrj73LN96LcWcz62V19FjAg==}
-    engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
-    deprecated: This version has a security vulnerability. Please upgrade to a patched version. See https://nextjs.org/blog/CVE-2025-66478 for more details.
+  next@16.2.10:
+    resolution: {integrity: sha512-2som5AVXb3kE6Yjine3/mNbBayYF58eguBWIVVUdr1y/L426xyVEgYxgBG+1QC34P2x5E+tcDup6XkuOAX3dCA==}
+    engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
-      '@playwright/test': ^1.41.2
+      '@playwright/test': ^1.51.1
       babel-plugin-react-compiler: '*'
       react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
       react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
@@ -6912,10 +6789,10 @@ packages:
     peerDependencies:
       react: ^18.3.1
 
-  react-dom@19.2.5:
-    resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
+  react-dom@19.2.7:
+    resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
     peerDependencies:
-      react: ^19.2.5
+      react: ^19.2.7
 
   react-hook-form@7.73.1:
     resolution: {integrity: sha512-VAfVYOPcx3piiEVQy95vyFmBwbVUsP/AUIN+mpFG8h11yshDd444nn0VyfaGWSRnhOLVgiDu7HIuBtAIzxn9dA==}
@@ -6967,8 +6844,8 @@ packages:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
 
-  react@19.2.5:
-    resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
+  react@19.2.7:
+    resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
     engines: {node: '>=0.10.0'}
 
   read-yaml-file@1.1.0:
@@ -7224,10 +7101,6 @@ packages:
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
-  sharp@0.33.5:
-    resolution: {integrity: sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
@@ -7268,9 +7141,6 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
-
-  simple-swizzle@0.2.4:
-    resolution: {integrity: sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==}
 
   sirv@3.0.2:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
@@ -7354,10 +7224,6 @@ packages:
     peerDependenciesMeta:
       prettier:
         optional: true
-
-  streamsearch@1.1.0:
-    resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
-    engines: {node: '>=10.0.0'}
 
   strict-event-emitter@0.5.1:
     resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
@@ -9032,11 +8898,11 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@floating-ui/react-dom@2.1.8(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@floating-ui/react-dom@2.1.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@floating-ui/dom': 1.7.6
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
 
   '@floating-ui/utils@0.2.11': {}
 
@@ -9062,19 +8928,9 @@ snapshots:
 
   '@img/colour@1.1.0': {}
 
-  '@img/sharp-darwin-arm64@0.33.5':
-    optionalDependencies:
-      '@img/sharp-libvips-darwin-arm64': 1.0.4
-    optional: true
-
   '@img/sharp-darwin-arm64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-darwin-arm64': 1.2.4
-    optional: true
-
-  '@img/sharp-darwin-x64@0.33.5':
-    optionalDependencies:
-      '@img/sharp-libvips-darwin-x64': 1.0.4
     optional: true
 
   '@img/sharp-darwin-x64@0.34.5':
@@ -9082,25 +8938,13 @@ snapshots:
       '@img/sharp-libvips-darwin-x64': 1.2.4
     optional: true
 
-  '@img/sharp-libvips-darwin-arm64@1.0.4':
-    optional: true
-
   '@img/sharp-libvips-darwin-arm64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-darwin-x64@1.0.4':
     optional: true
 
   '@img/sharp-libvips-darwin-x64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linux-arm64@1.0.4':
-    optional: true
-
   '@img/sharp-libvips-linux-arm64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-arm@1.0.5':
     optional: true
 
   '@img/sharp-libvips-linux-arm@1.2.4':
@@ -9112,43 +8956,21 @@ snapshots:
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linux-s390x@1.0.4':
-    optional: true
-
   '@img/sharp-libvips-linux-s390x@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-x64@1.0.4':
     optional: true
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
-    optional: true
-
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linuxmusl-x64@1.0.4':
     optional: true
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     optional: true
 
-  '@img/sharp-linux-arm64@0.33.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-arm64': 1.0.4
-    optional: true
-
   '@img/sharp-linux-arm64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linux-arm64': 1.2.4
-    optional: true
-
-  '@img/sharp-linux-arm@0.33.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-arm': 1.0.5
     optional: true
 
   '@img/sharp-linux-arm@0.34.5':
@@ -9166,19 +8988,9 @@ snapshots:
       '@img/sharp-libvips-linux-riscv64': 1.2.4
     optional: true
 
-  '@img/sharp-linux-s390x@0.33.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-s390x': 1.0.4
-    optional: true
-
   '@img/sharp-linux-s390x@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linux-s390x': 1.2.4
-    optional: true
-
-  '@img/sharp-linux-x64@0.33.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-x64': 1.0.4
     optional: true
 
   '@img/sharp-linux-x64@0.34.5':
@@ -9186,29 +8998,14 @@ snapshots:
       '@img/sharp-libvips-linux-x64': 1.2.4
     optional: true
 
-  '@img/sharp-linuxmusl-arm64@0.33.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-arm64': 1.0.4
-    optional: true
-
   '@img/sharp-linuxmusl-arm64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
     optional: true
 
-  '@img/sharp-linuxmusl-x64@0.33.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-x64': 1.0.4
-    optional: true
-
   '@img/sharp-linuxmusl-x64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linuxmusl-x64': 1.2.4
-    optional: true
-
-  '@img/sharp-wasm32@0.33.5':
-    dependencies:
-      '@emnapi/runtime': 1.10.0
     optional: true
 
   '@img/sharp-wasm32@0.34.5':
@@ -9219,13 +9016,7 @@ snapshots:
   '@img/sharp-win32-arm64@0.34.5':
     optional: true
 
-  '@img/sharp-win32-ia32@0.33.5':
-    optional: true
-
   '@img/sharp-win32-ia32@0.34.5':
-    optional: true
-
-  '@img/sharp-win32-x64@0.33.5':
     optional: true
 
   '@img/sharp-win32-x64@0.34.5':
@@ -9576,34 +9367,34 @@ snapshots:
 
   '@neoconfetti/react@1.0.0': {}
 
-  '@next/env@15.1.4': {}
+  '@next/env@16.2.10': {}
 
   '@next/eslint-plugin-next@15.5.15':
     dependencies:
       fast-glob: 3.3.1
 
-  '@next/swc-darwin-arm64@15.1.4':
+  '@next/swc-darwin-arm64@16.2.10':
     optional: true
 
-  '@next/swc-darwin-x64@15.1.4':
+  '@next/swc-darwin-x64@16.2.10':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@15.1.4':
+  '@next/swc-linux-arm64-gnu@16.2.10':
     optional: true
 
-  '@next/swc-linux-arm64-musl@15.1.4':
+  '@next/swc-linux-arm64-musl@16.2.10':
     optional: true
 
-  '@next/swc-linux-x64-gnu@15.1.4':
+  '@next/swc-linux-x64-gnu@16.2.10':
     optional: true
 
-  '@next/swc-linux-x64-musl@15.1.4':
+  '@next/swc-linux-x64-musl@16.2.10':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@15.1.4':
+  '@next/swc-win32-arm64-msvc@16.2.10':
     optional: true
 
-  '@next/swc-win32-x64-msvc@15.1.4':
+  '@next/swc-win32-x64-msvc@16.2.10':
     optional: true
 
   '@nodelib/fs.scandir@2.1.5':
@@ -9917,14 +9708,14 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-accessible-icon@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@radix-ui/react-accessible-icon@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/react-accordion@1.2.12(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -9943,22 +9734,22 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-accordion@1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@radix-ui/react-accordion@1.2.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-collapsible': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
+      '@radix-ui/react-collapsible': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/react-alert-dialog@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -9974,19 +9765,19 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-alert-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@radix-ui/react-alert-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.5)
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/react-arrow@1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -9997,14 +9788,14 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/react-aspect-ratio@1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -10015,14 +9806,14 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-aspect-ratio@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@radix-ui/react-aspect-ratio@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/react-avatar@1.1.10(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -10037,18 +9828,18 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-avatar@1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@radix-ui/react-avatar@1.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/react-checkbox@1.3.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -10066,21 +9857,21 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-checkbox@1.3.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@radix-ui/react-checkbox@1.3.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/react-collapsible@1.1.12(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -10098,21 +9889,21 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-collapsible@1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@radix-ui/react-collapsible@1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/react-collection@1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -10126,17 +9917,17 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-collection@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@radix-ui/react-collection@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.5)
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/react-compose-refs@1.1.2(@types/react@18.3.28)(react@18.3.1)':
     dependencies:
@@ -10144,11 +9935,11 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
 
-  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.14)(react@19.2.5)':
+  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
-      react: 19.2.5
+      react: 19.2.7
     optionalDependencies:
-      '@types/react': 19.2.14
+      '@types/react': 19.2.17
 
   '@radix-ui/react-context-menu@2.2.16(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -10164,19 +9955,19 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-context-menu@2.2.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@radix-ui/react-context-menu@2.2.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/react-context@1.1.2(@types/react@18.3.28)(react@18.3.1)':
     dependencies:
@@ -10184,11 +9975,11 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
 
-  '@radix-ui/react-context@1.1.2(@types/react@19.2.14)(react@19.2.5)':
+  '@radix-ui/react-context@1.1.2(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
-      react: 19.2.5
+      react: 19.2.7
     optionalDependencies:
-      '@types/react': 19.2.14
+      '@types/react': 19.2.17
 
   '@radix-ui/react-dialog@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -10212,27 +10003,27 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@radix-ui/react-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.17)(react@19.2.7)
       aria-hidden: 1.2.6
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
-      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-remove-scroll: 2.7.2(@types/react@19.2.17)(react@19.2.7)
     optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/react-direction@1.1.1(@types/react@18.3.28)(react@18.3.1)':
     dependencies:
@@ -10240,11 +10031,11 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
 
-  '@radix-ui/react-direction@1.1.1(@types/react@19.2.14)(react@19.2.5)':
+  '@radix-ui/react-direction@1.1.1(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
-      react: 19.2.5
+      react: 19.2.7
     optionalDependencies:
-      '@types/react': 19.2.14
+      '@types/react': 19.2.17
 
   '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -10259,18 +10050,18 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/react-dropdown-menu@2.1.16(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -10287,20 +10078,20 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-dropdown-menu@2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@radix-ui/react-dropdown-menu@2.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/react-focus-guards@1.1.3(@types/react@18.3.28)(react@18.3.1)':
     dependencies:
@@ -10308,11 +10099,11 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
 
-  '@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.14)(react@19.2.5)':
+  '@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
-      react: 19.2.5
+      react: 19.2.7
     optionalDependencies:
-      '@types/react': 19.2.14
+      '@types/react': 19.2.17
 
   '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -10325,16 +10116,16 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/react-form@0.1.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -10350,19 +10141,19 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-form@0.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@radix-ui/react-form@0.1.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-label': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-label': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/react-hover-card@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -10381,22 +10172,22 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-hover-card@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@radix-ui/react-hover-card@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/react-id@1.1.1(@types/react@18.3.28)(react@18.3.1)':
     dependencies:
@@ -10405,12 +10196,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
 
-  '@radix-ui/react-id@1.1.1(@types/react@19.2.14)(react@19.2.5)':
+  '@radix-ui/react-id@1.1.1(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      react: 19.2.5
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
     optionalDependencies:
-      '@types/react': 19.2.14
+      '@types/react': 19.2.17
 
   '@radix-ui/react-label@2.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -10421,14 +10212,14 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-label@2.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@radix-ui/react-label@2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/react-menu@2.1.16(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -10456,31 +10247,31 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-menu@2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@radix-ui/react-menu@2.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.17)(react@19.2.7)
       aria-hidden: 1.2.6
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
-      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-remove-scroll: 2.7.2(@types/react@19.2.17)(react@19.2.7)
     optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/react-menubar@1.1.16(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -10500,23 +10291,23 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-menubar@1.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@radix-ui/react-menubar@1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/react-navigation-menu@1.2.14(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -10540,27 +10331,27 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-navigation-menu@1.2.14(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@radix-ui/react-navigation-menu@1.2.14(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/react-one-time-password-field@0.1.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -10582,25 +10373,25 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-one-time-password-field@0.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@radix-ui/react-one-time-password-field@0.1.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/number': 1.1.1
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/react-password-toggle-field@0.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -10618,21 +10409,21 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-password-toggle-field@0.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@radix-ui/react-password-toggle-field@0.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.2.14)(react@19.2.5)
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/react-popover@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -10657,28 +10448,28 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.17)(react@19.2.7)
       aria-hidden: 1.2.6
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
-      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-remove-scroll: 2.7.2(@types/react@19.2.17)(react@19.2.7)
     optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/react-popper@1.2.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -10698,23 +10489,23 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-popper@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@radix-ui/react-popper@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-use-rect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-rect': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.17)(react@19.2.7)
       '@radix-ui/rect': 1.1.1
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/react-portal@1.1.9(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -10726,15 +10517,15 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/react-presence@1.1.5(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -10746,15 +10537,15 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/react-primitive@2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -10765,14 +10556,14 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.5)
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/react-progress@1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -10784,15 +10575,15 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-progress@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@radix-ui/react-progress@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/react-radio-group@1.3.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -10812,23 +10603,23 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-radio-group@1.3.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@radix-ui/react-radio-group@1.3.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/react-roving-focus@1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -10847,22 +10638,22 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-roving-focus@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@radix-ui/react-roving-focus@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/react-scroll-area@1.2.10(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -10881,22 +10672,22 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-scroll-area@1.2.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@radix-ui/react-scroll-area@1.2.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/number': 1.1.1
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/react-select@2.2.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -10927,34 +10718,34 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-select@2.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@radix-ui/react-select@2.2.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/number': 1.1.1
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       aria-hidden: 1.2.6
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
-      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-remove-scroll: 2.7.2(@types/react@19.2.17)(react@19.2.7)
     optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/react-separator@1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -10965,14 +10756,14 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-separator@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@radix-ui/react-separator@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/react-slider@1.3.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -10993,24 +10784,24 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-slider@1.3.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@radix-ui/react-slider@1.3.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/number': 1.1.1
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/react-slot@1.2.3(@types/react@18.3.28)(react@18.3.1)':
     dependencies:
@@ -11019,12 +10810,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
 
-  '@radix-ui/react-slot@1.2.3(@types/react@19.2.14)(react@19.2.5)':
+  '@radix-ui/react-slot@1.2.3(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      react: 19.2.5
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
     optionalDependencies:
-      '@types/react': 19.2.14
+      '@types/react': 19.2.17
 
   '@radix-ui/react-switch@1.2.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -11041,20 +10832,20 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-switch@1.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@radix-ui/react-switch@1.2.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/react-tabs@1.1.13(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -11072,21 +10863,21 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-tabs@1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@radix-ui/react-tabs@1.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/react-toast@1.2.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -11108,25 +10899,25 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-toast@1.2.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@radix-ui/react-toast@1.2.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/react-toggle-group@1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -11143,20 +10934,20 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-toggle-group@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@radix-ui/react-toggle-group@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-toggle': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-toggle': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/react-toggle@1.1.10(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -11169,16 +10960,16 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-toggle@1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@radix-ui/react-toggle@1.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/react-toolbar@1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -11195,20 +10986,20 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-toolbar@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@radix-ui/react-toolbar@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-separator': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-toggle-group': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-separator': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-toggle-group': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/react-tooltip@1.2.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -11230,25 +11021,25 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/react-use-callback-ref@1.1.1(@types/react@18.3.28)(react@18.3.1)':
     dependencies:
@@ -11256,11 +11047,11 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
 
-  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.14)(react@19.2.5)':
+  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
-      react: 19.2.5
+      react: 19.2.7
     optionalDependencies:
-      '@types/react': 19.2.14
+      '@types/react': 19.2.17
 
   '@radix-ui/react-use-controllable-state@1.2.2(@types/react@18.3.28)(react@18.3.1)':
     dependencies:
@@ -11270,13 +11061,13 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
 
-  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.2.14)(react@19.2.5)':
+  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
-      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      react: 19.2.5
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
     optionalDependencies:
-      '@types/react': 19.2.14
+      '@types/react': 19.2.17
 
   '@radix-ui/react-use-effect-event@0.0.2(@types/react@18.3.28)(react@18.3.1)':
     dependencies:
@@ -11285,12 +11076,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
 
-  '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.2.14)(react@19.2.5)':
+  '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      react: 19.2.5
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
     optionalDependencies:
-      '@types/react': 19.2.14
+      '@types/react': 19.2.17
 
   '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@18.3.28)(react@18.3.1)':
     dependencies:
@@ -11299,12 +11090,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
 
-  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.2.14)(react@19.2.5)':
+  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      react: 19.2.5
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
     optionalDependencies:
-      '@types/react': 19.2.14
+      '@types/react': 19.2.17
 
   '@radix-ui/react-use-is-hydrated@0.1.0(@types/react@18.3.28)(react@18.3.1)':
     dependencies:
@@ -11313,12 +11104,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
 
-  '@radix-ui/react-use-is-hydrated@0.1.0(@types/react@19.2.14)(react@19.2.5)':
+  '@radix-ui/react-use-is-hydrated@0.1.0(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
-      react: 19.2.5
-      use-sync-external-store: 1.6.0(react@19.2.5)
+      react: 19.2.7
+      use-sync-external-store: 1.6.0(react@19.2.7)
     optionalDependencies:
-      '@types/react': 19.2.14
+      '@types/react': 19.2.17
 
   '@radix-ui/react-use-layout-effect@1.1.1(@types/react@18.3.28)(react@18.3.1)':
     dependencies:
@@ -11326,11 +11117,11 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
 
-  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.14)(react@19.2.5)':
+  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
-      react: 19.2.5
+      react: 19.2.7
     optionalDependencies:
-      '@types/react': 19.2.14
+      '@types/react': 19.2.17
 
   '@radix-ui/react-use-previous@1.1.1(@types/react@18.3.28)(react@18.3.1)':
     dependencies:
@@ -11338,11 +11129,11 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
 
-  '@radix-ui/react-use-previous@1.1.1(@types/react@19.2.14)(react@19.2.5)':
+  '@radix-ui/react-use-previous@1.1.1(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
-      react: 19.2.5
+      react: 19.2.7
     optionalDependencies:
-      '@types/react': 19.2.14
+      '@types/react': 19.2.17
 
   '@radix-ui/react-use-rect@1.1.1(@types/react@18.3.28)(react@18.3.1)':
     dependencies:
@@ -11351,12 +11142,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
 
-  '@radix-ui/react-use-rect@1.1.1(@types/react@19.2.14)(react@19.2.5)':
+  '@radix-ui/react-use-rect@1.1.1(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
       '@radix-ui/rect': 1.1.1
-      react: 19.2.5
+      react: 19.2.7
     optionalDependencies:
-      '@types/react': 19.2.14
+      '@types/react': 19.2.17
 
   '@radix-ui/react-use-size@1.1.1(@types/react@18.3.28)(react@18.3.1)':
     dependencies:
@@ -11365,12 +11156,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
 
-  '@radix-ui/react-use-size@1.1.1(@types/react@19.2.14)(react@19.2.5)':
+  '@radix-ui/react-use-size@1.1.1(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      react: 19.2.5
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
     optionalDependencies:
-      '@types/react': 19.2.14
+      '@types/react': 19.2.17
 
   '@radix-ui/react-visually-hidden@1.2.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -11381,14 +11172,14 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@radix-ui/react-visually-hidden@1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@radix-ui/react-visually-hidden@1.2.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/rect@1.1.1': {}
 
@@ -11830,8 +11621,6 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@swc/counter@0.1.3': {}
-
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
@@ -12097,16 +11886,16 @@ snapshots:
     dependencies:
       '@types/react': 18.3.28
 
-  '@types/react-dom@19.2.3(@types/react@19.2.14)':
+  '@types/react-dom@19.2.3(@types/react@19.2.17)':
     dependencies:
-      '@types/react': 19.2.14
+      '@types/react': 19.2.17
 
   '@types/react@18.3.28':
     dependencies:
       '@types/prop-types': 15.7.15
       csstype: 3.2.3
 
-  '@types/react@19.2.14':
+  '@types/react@19.2.17':
     dependencies:
       csstype: 3.2.3
 
@@ -12515,7 +12304,7 @@ snapshots:
       '@vue/shared': 3.5.25
       estree-walker: 2.0.2
       magic-string: 0.30.21
-      postcss: 8.5.6
+      postcss: 8.5.10
       source-map-js: 1.2.1
 
   '@vue/compiler-ssr@3.5.25':
@@ -12853,10 +12642,6 @@ snapshots:
       esbuild: 0.27.7
       load-tsconfig: 0.2.5
 
-  busboy@1.6.0:
-    dependencies:
-      streamsearch: 1.1.0
-
   bytes@3.1.2: {}
 
   cac@6.7.14: {}
@@ -12987,18 +12772,6 @@ snapshots:
   color-name@1.1.3: {}
 
   color-name@1.1.4: {}
-
-  color-string@1.9.1:
-    dependencies:
-      color-name: 1.1.4
-      simple-swizzle: 0.2.4
-    optional: true
-
-  color@4.2.3:
-    dependencies:
-      color-convert: 2.0.1
-      color-string: 1.9.1
-    optional: true
 
   colorette@2.0.20: {}
 
@@ -14083,14 +13856,14 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  framer-motion@12.38.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+  framer-motion@12.38.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       motion-dom: 12.38.0
       motion-utils: 12.36.0
       tslib: 2.8.1
     optionalDependencies:
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
 
   fresh@2.0.0: {}
 
@@ -14510,9 +14283,6 @@ snapshots:
       get-intrinsic: 1.3.0
 
   is-arrayish@0.2.1: {}
-
-  is-arrayish@0.3.4:
-    optional: true
 
   is-async-function@2.1.1:
     dependencies:
@@ -15031,10 +14801,10 @@ snapshots:
       '@types/react': 18.3.28
       react: 18.3.1
 
-  lucide-react@0.475.0(@types/react@19.2.14)(react@19.2.5):
+  lucide-react@0.475.0(@types/react@19.2.17)(react@19.2.7):
     dependencies:
-      '@types/react': 19.2.14
-      react: 19.2.5
+      '@types/react': 19.2.17
+      react: 19.2.7
 
   lz-string@1.5.0: {}
 
@@ -15450,13 +15220,13 @@ snapshots:
 
   motion-utils@12.36.0: {}
 
-  motion@12.38.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+  motion@12.38.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
-      framer-motion: 12.38.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      framer-motion: 12.38.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       tslib: 2.8.1
     optionalDependencies:
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
 
   mri@1.2.0: {}
 
@@ -15523,32 +15293,31 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next-themes@0.4.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+  next-themes@0.4.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
 
-  next@15.1.4(@babel/core@7.29.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+  next@16.2.10(@babel/core@7.29.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
-      '@next/env': 15.1.4
-      '@swc/counter': 0.1.3
+      '@next/env': 16.2.10
       '@swc/helpers': 0.5.15
-      busboy: 1.6.0
+      baseline-browser-mapping: 2.10.20
       caniuse-lite: 1.0.30001788
       postcss: 8.4.31
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
-      styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.5)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.7)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 15.1.4
-      '@next/swc-darwin-x64': 15.1.4
-      '@next/swc-linux-arm64-gnu': 15.1.4
-      '@next/swc-linux-arm64-musl': 15.1.4
-      '@next/swc-linux-x64-gnu': 15.1.4
-      '@next/swc-linux-x64-musl': 15.1.4
-      '@next/swc-win32-arm64-msvc': 15.1.4
-      '@next/swc-win32-x64-msvc': 15.1.4
-      sharp: 0.33.5
+      '@next/swc-darwin-arm64': 16.2.10
+      '@next/swc-darwin-x64': 16.2.10
+      '@next/swc-linux-arm64-gnu': 16.2.10
+      '@next/swc-linux-arm64-musl': 16.2.10
+      '@next/swc-linux-x64-gnu': 16.2.10
+      '@next/swc-linux-x64-musl': 16.2.10
+      '@next/swc-win32-arm64-msvc': 16.2.10
+      '@next/swc-win32-x64-msvc': 16.2.10
+      sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
@@ -16068,68 +15837,68 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  radix-ui@1.4.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+  radix-ui@1.4.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-accessible-icon': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-accordion': 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-alert-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-aspect-ratio': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-avatar': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-checkbox': 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-collapsible': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-context-menu': 2.2.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-dropdown-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-form': 0.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-hover-card': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-label': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-menubar': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-navigation-menu': 1.2.14(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-one-time-password-field': 0.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-password-toggle-field': 0.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-popover': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-progress': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-radio-group': 1.3.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-scroll-area': 1.2.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-select': 2.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-separator': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-slider': 1.3.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-switch': 1.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-toast': 1.2.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-toggle': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-toggle-group': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-toolbar': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-tooltip': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
+      '@radix-ui/react-accessible-icon': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-accordion': 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-alert-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-aspect-ratio': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-avatar': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-checkbox': 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-collapsible': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context-menu': 2.2.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-dropdown-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-form': 0.1.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-hover-card': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-label': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-menubar': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-navigation-menu': 1.2.14(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-one-time-password-field': 0.1.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-password-toggle-field': 0.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-popover': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-progress': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-radio-group': 1.3.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-scroll-area': 1.2.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-select': 2.2.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-separator': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-slider': 1.3.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-switch': 1.2.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-toast': 1.2.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-toggle': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-toggle-group': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-toolbar': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-tooltip': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   range-parser@1.2.1: {}
 
@@ -16165,9 +15934,9 @@ snapshots:
       react: 18.3.1
       scheduler: 0.23.2
 
-  react-dom@19.2.5(react@19.2.5):
+  react-dom@19.2.7(react@19.2.7):
     dependencies:
-      react: 19.2.5
+      react: 19.2.7
       scheduler: 0.27.0
 
   react-hook-form@7.73.1(react@18.3.1):
@@ -16188,13 +15957,13 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
 
-  react-remove-scroll-bar@2.3.8(@types/react@19.2.14)(react@19.2.5):
+  react-remove-scroll-bar@2.3.8(@types/react@19.2.17)(react@19.2.7):
     dependencies:
-      react: 19.2.5
-      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.7
+      react-style-singleton: 2.2.3(@types/react@19.2.17)(react@19.2.7)
       tslib: 2.8.1
     optionalDependencies:
-      '@types/react': 19.2.14
+      '@types/react': 19.2.17
 
   react-remove-scroll@2.7.2(@types/react@18.3.28)(react@18.3.1):
     dependencies:
@@ -16207,16 +15976,16 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
 
-  react-remove-scroll@2.7.2(@types/react@19.2.14)(react@19.2.5):
+  react-remove-scroll@2.7.2(@types/react@19.2.17)(react@19.2.7):
     dependencies:
-      react: 19.2.5
-      react-remove-scroll-bar: 2.3.8(@types/react@19.2.14)(react@19.2.5)
-      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.7
+      react-remove-scroll-bar: 2.3.8(@types/react@19.2.17)(react@19.2.7)
+      react-style-singleton: 2.2.3(@types/react@19.2.17)(react@19.2.7)
       tslib: 2.8.1
-      use-callback-ref: 1.3.3(@types/react@19.2.14)(react@19.2.5)
-      use-sidecar: 1.1.3(@types/react@19.2.14)(react@19.2.5)
+      use-callback-ref: 1.3.3(@types/react@19.2.17)(react@19.2.7)
+      use-sidecar: 1.1.3(@types/react@19.2.17)(react@19.2.7)
     optionalDependencies:
-      '@types/react': 19.2.14
+      '@types/react': 19.2.17
 
   react-style-singleton@2.2.3(@types/react@18.3.28)(react@18.3.1):
     dependencies:
@@ -16226,19 +15995,19 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
 
-  react-style-singleton@2.2.3(@types/react@19.2.14)(react@19.2.5):
+  react-style-singleton@2.2.3(@types/react@19.2.17)(react@19.2.7):
     dependencies:
       get-nonce: 1.0.1
-      react: 19.2.5
+      react: 19.2.7
       tslib: 2.8.1
     optionalDependencies:
-      '@types/react': 19.2.14
+      '@types/react': 19.2.17
 
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
 
-  react@19.2.5: {}
+  react@19.2.7: {}
 
   read-yaml-file@1.1.0:
     dependencies:
@@ -16609,33 +16378,6 @@ snapshots:
 
   setprototypeof@1.2.0: {}
 
-  sharp@0.33.5:
-    dependencies:
-      color: 4.2.3
-      detect-libc: 2.1.2
-      semver: 7.7.4
-    optionalDependencies:
-      '@img/sharp-darwin-arm64': 0.33.5
-      '@img/sharp-darwin-x64': 0.33.5
-      '@img/sharp-libvips-darwin-arm64': 1.0.4
-      '@img/sharp-libvips-darwin-x64': 1.0.4
-      '@img/sharp-libvips-linux-arm': 1.0.5
-      '@img/sharp-libvips-linux-arm64': 1.0.4
-      '@img/sharp-libvips-linux-s390x': 1.0.4
-      '@img/sharp-libvips-linux-x64': 1.0.4
-      '@img/sharp-libvips-linuxmusl-arm64': 1.0.4
-      '@img/sharp-libvips-linuxmusl-x64': 1.0.4
-      '@img/sharp-linux-arm': 0.33.5
-      '@img/sharp-linux-arm64': 0.33.5
-      '@img/sharp-linux-s390x': 0.33.5
-      '@img/sharp-linux-x64': 0.33.5
-      '@img/sharp-linuxmusl-arm64': 0.33.5
-      '@img/sharp-linuxmusl-x64': 0.33.5
-      '@img/sharp-wasm32': 0.33.5
-      '@img/sharp-win32-ia32': 0.33.5
-      '@img/sharp-win32-x64': 0.33.5
-    optional: true
-
   sharp@0.34.5:
     dependencies:
       '@img/colour': 1.1.0
@@ -16717,11 +16459,6 @@ snapshots:
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
-
-  simple-swizzle@0.2.4:
-    dependencies:
-      is-arrayish: 0.3.4
-    optional: true
 
   sirv@3.0.2:
     dependencies:
@@ -16813,8 +16550,6 @@ snapshots:
       - react
       - react-dom
       - utf-8-validate
-
-  streamsearch@1.1.0: {}
 
   strict-event-emitter@0.5.1: {}
 
@@ -16923,10 +16658,10 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
-  styled-jsx@5.1.6(@babel/core@7.29.0)(react@19.2.5):
+  styled-jsx@5.1.6(@babel/core@7.29.0)(react@19.2.7):
     dependencies:
       client-only: 0.0.1
-      react: 19.2.5
+      react: 19.2.7
     optionalDependencies:
       '@babel/core': 7.29.0
 
@@ -17408,12 +17143,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
 
-  use-callback-ref@1.3.3(@types/react@19.2.14)(react@19.2.5):
+  use-callback-ref@1.3.3(@types/react@19.2.17)(react@19.2.7):
     dependencies:
-      react: 19.2.5
+      react: 19.2.7
       tslib: 2.8.1
     optionalDependencies:
-      '@types/react': 19.2.14
+      '@types/react': 19.2.17
 
   use-sidecar@1.1.3(@types/react@18.3.28)(react@18.3.1):
     dependencies:
@@ -17423,21 +17158,21 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
 
-  use-sidecar@1.1.3(@types/react@19.2.14)(react@19.2.5):
+  use-sidecar@1.1.3(@types/react@19.2.17)(react@19.2.7):
     dependencies:
       detect-node-es: 1.1.0
-      react: 19.2.5
+      react: 19.2.7
       tslib: 2.8.1
     optionalDependencies:
-      '@types/react': 19.2.14
+      '@types/react': 19.2.17
 
   use-sync-external-store@1.6.0(react@18.3.1):
     dependencies:
       react: 18.3.1
 
-  use-sync-external-store@1.6.0(react@19.2.5):
+  use-sync-external-store@1.6.0(react@19.2.7):
     dependencies:
-      react: 19.2.5
+      react: 19.2.7
 
   util-deprecate@1.0.2: {}
 


### PR DESCRIPTION
## What changed

### Component guide registry

- Keep the existing component code registry and add a parallel guide registry generated from co-located `guide.md` files.
- Add `design-system guide <component>` to fetch a guide and print its Markdown content directly to stdout.
- Add source-backed, web-platform authoring guides for all 13 existing UI components.
- Add a regression test for guide lookup, component-name normalization, and exact Markdown output.

### Docs runtime upgrade

- Upgrade the docs app from Next.js 15.1.4 to the latest stable Next.js 16.2.10 release.
- Align React, React DOM, and their type packages with the current stable React 19.2 releases.
- Replace removed `next lint` usage with ESLint CLI and update lint-staged file forwarding.
- Remove the obsolete explicit Turbopack dev flag.
- Update Velite development detection and accept Next 16's generated TypeScript route configuration.

## Why

The current CLI distributes ready-made component code through `add`. Codex also needs reusable expert knowledge that can be combined with a project's product context, foundations, and tokens to author a project-specific component SSOT. This adds that knowledge path without replacing or changing the existing code-copy workflow.

The docs app was also pinned to an early Next.js 15 release. Moving to the current stable release keeps the deployment surface supported and applies the required Next.js 16 lint, development-mode, and TypeScript migrations.

## Behavior

During the existing CLI registry build, each `packages/ui/src/component/<name>/guide.md` is emitted as `app/docs/public/guides/<name>.json` with a `{ name, content }` shape. The new CLI command validates that response and writes only `content` to stdout so agent workflows can consume the Markdown without terminal decoration.

The docs app continues to use static export and Velite. Next.js 16 now builds it with stable Turbopack defaults.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm --filter @jongh/cli test` (4 files, 19 tests)
- `pnpm --filter @jongh/cli check-type`
- targeted ESLint for changed CLI TypeScript files
- Prettier check for all 13 guide documents
- `pnpm --filter docs lint`
- `pnpm --filter docs check-type`
- `pnpm --filter docs build` with Next.js 16.2.10
- `pnpm turbo build` (CLI registry, docs static export, Storybook, and package builds)
- verified all 13 generated guide registries match their source Markdown byte-for-byte
- verified the built CLI retrieves the local Button guide and prints the exact source Markdown
- independent code review: approved with no critical or high-severity findings

## Upgrade references

- https://nextjs.org/docs/app/guides/upgrading/version-16
- https://www.npmjs.com/package/next?activeTab=versions
