### PR TITLE
chore: release @jongh/cli 4.1.0

### DIFF
--- a/.changeset/full-points-film.md
+++ b/.changeset/full-points-film.md
@@ -1,0 +1,5 @@
+---
+"@jongh/cli": minor
+---
+
+Add component guide registry generation and the guide lookup command.


### PR DESCRIPTION
## What changed

- Add a Changeset for `@jongh/cli`.
- Mark the component guide registry and `guide` lookup command as a minor release.

## Release result

Applying this Changeset bumps `@jongh/cli` from `4.0.0` to `4.1.0`.

## Validation

- Generated through the official Changesets interactive CLI.
- `changeset status` resolves the release plan to `@jongh/cli@4.1.0`.
